### PR TITLE
feat 13: map and filter implementation with tests.

### DIFF
--- a/packages/contracts/Scarb.toml
+++ b/packages/contracts/Scarb.toml
@@ -3,6 +3,7 @@ name = "lore"
 cairo-version = "=2.9.2"
 version = "0.1.0"
 edition = "2024_07"
+experimental-features = ["associated_item_constraints"]
 
 [cairo]
 sierra-replace-ids = true

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -1899,8 +1899,8 @@
       ]
     },
     {
-      "address": "0x7d3a2943a2c0632957e70bc33e7210cd1c57cbe195d86f3faa0cab4e0d7188c",
-      "class_hash": "0x4f2a159b8710260bbaa5f63c0239ddd19a39ef733b8c2efe34848f788a576b1",
+      "address": "0x5e945e03a7a2b8cc9c3f1f8bdd099f50aeee719257d36aef9d2013a3bb1df22",
+      "class_hash": "0x5c798c3acf0730d2490692447f79385bb3ee3391b55e0acefce4b853a06a363",
       "abi": [
         {
           "type": "impl",

--- a/packages/contracts/src/lib/a_lexer.cairo
+++ b/packages/contracts/src/lib/a_lexer.cairo
@@ -144,7 +144,10 @@ pub mod lexer {
     use lore::{
         components::{player::{Player, PlayerImpl}}, //
         constants::errors::Error, //
-        lib::{utils::ByteArrayTraitExt, dictionary::{get_dict_entry, initialize_dictionary}},
+        lib::{
+            utils::{ByteArrayTraitExt, ClousureTraitImp},
+            dictionary::{get_dict_entry, initialize_dictionary},
+        },
     };
 
 
@@ -154,6 +157,7 @@ pub mod lexer {
         initialize_dictionary(world);
         let words = message.split_into_words();
         let lowercased = lowercase(words.clone());
+        println!("lowercased using map: {:?}", lowercased);
         let tokens = match_tokens(world, lowercased);
         let mut command = Command {
             command_id: world.dispatcher.uuid().try_into().unwrap(),
@@ -248,6 +252,12 @@ pub mod lexer {
             lowercased.append(word.to_lowercase());
         };
         lowercased
+        // CANNOT BE USED CURRENTLY //
+    // Using the map clousure function, we can apply the lowercase function to each element in
+    // the array
+    // let lowercased = self.map(|word| word.to_lowercase());
+    // // Return the lowercased array
+    // lowercased
     }
 }
 


### PR DESCRIPTION
# WORK IN PROGRESS

# Description

Implementation of `map` and `filter` clousure funcs and tests.

## Related issues

Closes #13 

## Introduced changes

Implemented the closure functions `map` and `filter` alongside their corresponding tests.

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
