### PR TITLE
feat: implementation of Inventory/Container

### DIFF
--- a/packages/client/src/editor/components/FormComponents.tsx
+++ b/packages/client/src/editor/components/FormComponents.tsx
@@ -1,4 +1,3 @@
-import { Delete } from "lucide-react";
 import React, { useState } from "react";
 import type { ChangeEvent } from "react";
 import type { CairoCustomEnum } from "starknet";

--- a/packages/client/src/editor/components/inspectors/ContainerInspector.tsx
+++ b/packages/client/src/editor/components/inspectors/ContainerInspector.tsx
@@ -1,0 +1,79 @@
+import { type ChangeEvent } from "react";
+import {
+	type ActionMapContainer,
+	type Container,
+	containerActions,
+} from "@/lib/dojo_bindings/typescript/models.gen";
+import { ActionMapEditor, Toggle, Input } from "../FormComponents";
+import type { ComponentInspector } from "./useInspector";
+import { useInspector } from "./useInspector";
+
+export const ContainerInspector: ComponentInspector<Container> = ({
+	componentObject,
+	...props
+}) => {
+	const { handleInputChange, Inspector } = useInspector<Container>({
+		componentObject,
+		...props,
+		inputHandlers: {
+			is_container: (e, updatedObject) => {
+				const event = e as ChangeEvent<HTMLInputElement>;
+				updatedObject.is_container = event.target.checked;
+			},
+			can_be_opened: (e, updatedObject) => {
+				updatedObject.can_be_opened = e.target.checked;
+			},
+			can_receive_items: (e, updatedObject) => {
+				updatedObject.can_receive_items = e.target.checked;
+			},
+			is_open: (e, updatedObject) => {
+				updatedObject.is_open = e.target.checked;
+			},
+			num_slots: (e, updatedObject) => {
+				updatedObject.num_slots = e.target.value;
+			},
+			action_map: (e, updatedObject) => {
+				const newActionMap = e.target.value as unknown as ActionMapContainer[];
+				updatedObject.action_map = newActionMap;
+			},
+		},
+	});
+
+	if (!componentObject) return <div>Container not found</div>;
+
+	return (
+		<Inspector>
+			<Toggle
+				id="is_container"
+				value={componentObject.is_container}
+				onChange={handleInputChange}
+			/>
+			<Toggle
+				id="can_be_opened"
+				value={componentObject.can_be_opened}
+				onChange={handleInputChange}
+			/>
+			<Toggle
+				id="can_receive_items"
+				value={componentObject.can_receive_items}
+				onChange={handleInputChange}
+			/>
+			<Toggle
+				id="is_open"
+				value={componentObject.is_open}
+				onChange={handleInputChange}
+			/>
+			<Input
+				id="num_slots"
+				value={componentObject.num_slots.toString()}
+				onChange={handleInputChange}
+			/>
+			<ActionMapEditor
+				id="action_map"
+				value={componentObject.action_map}
+				onChange={handleInputChange}
+				cairoEnum={containerActions}
+			/>
+		</Inspector>
+	);
+};

--- a/packages/client/src/editor/components/inspectors/InventoryItemInspector.tsx
+++ b/packages/client/src/editor/components/inspectors/InventoryItemInspector.tsx
@@ -1,0 +1,85 @@
+import { type ChangeEvent, useMemo } from "react";
+import EditorData from "@/editor/data/editor.data";
+import { stringCairoEnum } from "@/editor/lib/schemas";
+import {
+	type ActionMapInventoryItem,
+	type InventoryItem,
+	inventoryItemActions,
+} from "@/lib/dojo_bindings/typescript/models.gen";
+import {
+	ActionMapEditor,
+	CairoEnumSelect,
+	Select,
+	Toggle,
+} from "../FormComponents";
+import type { ComponentInspector } from "./useInspector";
+import { useInspector } from "./useInspector";
+
+export const InventoryItemInspector: ComponentInspector<InventoryItem> = ({
+	componentObject,
+	...props
+}) => {
+  const { handleInputChange, Inspector } = useInspector<InventoryItem>({
+    componentObject,
+    ...props,
+    inputHandlers: {
+      is_inventory_item: (e, updatedObject) => {
+        const event = e as ChangeEvent<HTMLInputElement>;
+        updatedObject.is_inventory_item = event.target.checked;
+      },
+      owner_id: (e, updatedObject) => {
+        updatedObject.owner_id = e.target.value;
+      },
+      can_be_picked_up: (e, updatedObject) => {
+        updatedObject.can_be_picked_up = e.target.checked;
+      },
+      can_go_in_container: (e, updatedObject) => {
+        updatedObject.can_go_in_container = e.target.checked;
+      },
+      action_map: (e, updatedObject) => {
+        const newActionMap = e.target.value as unknown as ActionMapInventoryItem[];
+        updatedObject.action_map = newActionMap;
+      },
+    },
+	});
+
+	if (!componentObject) return <div>InventoryItem not found</div>;
+
+	return (
+		<Inspector>
+			<Toggle
+				id="is_inventory_item"
+				value={componentObject.is_inventory_item}
+				onChange={handleInputChange}
+			/>
+			<Select
+				id="owner_id"
+				defaultValue={componentObject.owner_id.toString()}
+				onChange={handleInputChange}
+				options={EditorData()
+					.getEntities()
+					.filter((e) => e.Entity !== undefined)
+					.map((e) => ({
+						value: e.Entity!.inst.toString(),
+						label: e.Entity.name,
+					}))}
+			/>
+			<Toggle
+				id="can_be_picked_up"
+				value={componentObject.can_be_picked_up}
+				onChange={handleInputChange}
+			/>
+			<Toggle
+				id="can_go_in_container"
+				value={componentObject.can_go_in_container}
+				onChange={handleInputChange}
+			/>
+			<ActionMapEditor
+				id="action_map"
+				value={componentObject.action_map}
+				onChange={handleInputChange}
+				cairoEnum={inventoryItemActions}
+			/>
+		</Inspector>
+	);
+}

--- a/packages/client/src/editor/components/inspectors/InventoryItemInspector.tsx
+++ b/packages/client/src/editor/components/inspectors/InventoryItemInspector.tsx
@@ -1,6 +1,5 @@
-import { type ChangeEvent, useMemo } from "react";
+import { type ChangeEvent } from "react";
 import EditorData from "@/editor/data/editor.data";
-import { stringCairoEnum } from "@/editor/lib/schemas";
 import {
 	type ActionMapInventoryItem,
 	type InventoryItem,
@@ -8,7 +7,6 @@ import {
 } from "@/lib/dojo_bindings/typescript/models.gen";
 import {
 	ActionMapEditor,
-	CairoEnumSelect,
 	Select,
 	Toggle,
 } from "../FormComponents";

--- a/packages/client/src/editor/components/inspectors/InventoryItemInspector.tsx
+++ b/packages/client/src/editor/components/inspectors/InventoryItemInspector.tsx
@@ -1,5 +1,4 @@
 import { type ChangeEvent } from "react";
-import EditorData from "@/editor/data/editor.data";
 import {
 	type ActionMapInventoryItem,
 	type InventoryItem,
@@ -7,7 +6,6 @@ import {
 } from "@/lib/dojo_bindings/typescript/models.gen";
 import {
 	ActionMapEditor,
-	Select,
 	Toggle,
 } from "../FormComponents";
 import type { ComponentInspector } from "./useInspector";
@@ -24,9 +22,6 @@ export const InventoryItemInspector: ComponentInspector<InventoryItem> = ({
       is_inventory_item: (e, updatedObject) => {
         const event = e as ChangeEvent<HTMLInputElement>;
         updatedObject.is_inventory_item = event.target.checked;
-      },
-      owner_id: (e, updatedObject) => {
-        updatedObject.owner_id = e.target.value;
       },
       can_be_picked_up: (e, updatedObject) => {
         updatedObject.can_be_picked_up = e.target.checked;
@@ -49,18 +44,6 @@ export const InventoryItemInspector: ComponentInspector<InventoryItem> = ({
 				id="is_inventory_item"
 				value={componentObject.is_inventory_item}
 				onChange={handleInputChange}
-			/>
-			<Select
-				id="owner_id"
-				defaultValue={componentObject.owner_id.toString()}
-				onChange={handleInputChange}
-				options={EditorData()
-					.getEntities()
-					.filter((e) => e.Entity !== undefined)
-					.map((e) => ({
-						value: e.Entity!.inst.toString(),
-						label: e.Entity.name,
-					}))}
 			/>
 			<Toggle
 				id="can_be_picked_up"

--- a/packages/client/src/editor/lib/components.ts
+++ b/packages/client/src/editor/lib/components.ts
@@ -9,6 +9,7 @@ import { ExitInspector } from "../components/inspectors/ExitInspector";
 import { InventoryItemInspector } from "../components/inspectors/InventoryItemInspector";
 import { InspectableInspector } from "../components/inspectors/InspectableInspector";
 import type { ComponentInspector } from "../components/inspectors/useInspector";
+import { ContainerInspector } from "../components/inspectors/ContainerInspector";
 import { createRandomName, randomKey } from "../editor.utils";
 import type { EntityCollection, WithStringEnums } from "./types";
 
@@ -81,6 +82,26 @@ export const createDefaultInventoryItemComponent = (
 		action_map: [
 			{ action: "pickup", inst: 0, action_fn: "UseItem" },
 			{ action: "drop", inst: 0, action_fn: "UseItem" },
+			{ action: "put", inst: 0, action_fn: "UseItem" },
+		],
+	},
+});
+
+export const createDefaultContainerComponent = (
+	entity: Entity,
+): WithStringEnums<Pick<SchemaType["lore"], "Container">> => ({
+	Container: {
+		...schema.lore.Container,
+		inst: entity.inst,
+		is_container: true,
+		can_be_opened: true,
+		can_receive_items: true,
+		is_open: true,
+		num_slots: 0,
+		item_ids: [],
+		action_map: [
+			{ action: "open", inst: 0, action_fn: "Open" },
+			{ action: "close", inst: 0, action_fn: "Close" },
 		],
 	},
 });
@@ -147,5 +168,11 @@ export const componentData: {
 		inspector: InventoryItemInspector,
 		icon: "📦",
 		creator: createDefaultInventoryItemComponent,
+	},
+	Container: {
+		order: 5,
+		inspector: ContainerInspector,
+		icon: "🎒",
+		creator: createDefaultContainerComponent,
 	},
 };

--- a/packages/client/src/editor/lib/components.ts
+++ b/packages/client/src/editor/lib/components.ts
@@ -80,9 +80,10 @@ export const createDefaultInventoryItemComponent = (
 		can_be_picked_up: false,
 		can_go_in_container: false,
 		action_map: [
-			{ action: "pickup", inst: 0, action_fn: "UseItem" },
-			{ action: "drop", inst: 0, action_fn: "UseItem" },
-			{ action: "put", inst: 0, action_fn: "UseItem" },
+			{ action: "pickup", inst: 0, action_fn: "PickupItem" },
+			{ action: "drop", inst: 0, action_fn: "DropItem" },
+			{ action: "put", inst: 0, action_fn: "PutItem" },
+			{ action: "use", inst: 0, action_fn: "UseItem" },
 		],
 	},
 });

--- a/packages/client/src/editor/lib/components.ts
+++ b/packages/client/src/editor/lib/components.ts
@@ -6,6 +6,7 @@ import {
 import { AreaInspector } from "../components/inspectors/AreaInspector";
 import { EntityInspector } from "../components/inspectors/EntityInspector";
 import { ExitInspector } from "../components/inspectors/ExitInspector";
+import { InventoryItemInspector } from "../components/inspectors/InventoryItemInspector";
 import { InspectableInspector } from "../components/inspectors/InspectableInspector";
 import type { ComponentInspector } from "../components/inspectors/useInspector";
 import { createRandomName, randomKey } from "../editor.utils";
@@ -67,6 +68,23 @@ export const createDefaultExitComponent = (
 	},
 });
 
+export const createDefaultInventoryItemComponent = (
+	entity: Entity,
+): WithStringEnums<Pick<SchemaType["lore"], "InventoryItem">> => ({
+	InventoryItem: {
+		...schema.lore.InventoryItem,
+		inst: entity.inst,
+		is_inventory_item: true,
+		owner_id: 0,
+		can_be_picked_up: false,
+		can_go_in_container: false,
+		action_map: [
+			{ action: "pickup", inst: 0, action_fn: "UseItem" },
+			{ action: "drop", inst: 0, action_fn: "UseItem" },
+		],
+	},
+});
+
 export const createDefaultChildToParentComponent = (
 	entity: Entity,
 ): WithStringEnums<Pick<SchemaType["lore"], "ChildToParent">> => ({
@@ -123,5 +141,11 @@ export const componentData: {
 		inspector: ExitInspector,
 		icon: "🚪",
 		creator: createDefaultExitComponent,
+	},
+	InventoryItem: {
+		order: 4,
+		inspector: InventoryItemInspector,
+		icon: "📦",
+		creator: createDefaultInventoryItemComponent,
 	},
 };

--- a/packages/client/src/editor/lib/components.ts
+++ b/packages/client/src/editor/lib/components.ts
@@ -99,10 +99,10 @@ export const createDefaultContainerComponent = (
 		can_receive_items: true,
 		is_open: true,
 		num_slots: 0,
-		item_ids: [],
 		action_map: [
 			{ action: "open", inst: 0, action_fn: "Open" },
 			{ action: "close", inst: 0, action_fn: "Close" },
+			{ action: "check", inst: 0, action_fn: "Check" },
 		],
 	},
 });

--- a/packages/client/src/editor/lib/components.ts
+++ b/packages/client/src/editor/lib/components.ts
@@ -83,6 +83,7 @@ export const createDefaultInventoryItemComponent = (
 			{ action: "pickup", inst: 0, action_fn: "PickupItem" },
 			{ action: "drop", inst: 0, action_fn: "DropItem" },
 			{ action: "put", inst: 0, action_fn: "PutItem" },
+			{ action: "take", inst: 0, action_fn: "TakeOutItem" },
 			{ action: "use", inst: 0, action_fn: "UseItem" },
 		],
 	},

--- a/packages/client/src/editor/lib/components.ts
+++ b/packages/client/src/editor/lib/components.ts
@@ -76,8 +76,8 @@ export const createDefaultInventoryItemComponent = (
 		inst: entity.inst,
 		is_inventory_item: true,
 		owner_id: 0,
-		can_be_picked_up: false,
-		can_go_in_container: false,
+		can_be_picked_up: true,
+		can_go_in_container: true,
 		action_map: [
 			{ action: "pickup", inst: 0, action_fn: "PickupItem" },
 			{ action: "drop", inst: 0, action_fn: "DropItem" },

--- a/packages/client/src/editor/publisher.ts
+++ b/packages/client/src/editor/publisher.ts
@@ -9,6 +9,8 @@ import {
 	exitActions,
 	type Inspectable,
 	inspectableActions,
+	type InventoryItem,
+	inventoryItemActions,
 	type ParentToChildren,
 } from "@/lib/dojo_bindings/typescript/models.gen";
 import { tick } from "@/lib/utils/utils";
@@ -85,6 +87,9 @@ const publishEntityCollection = async (collection: EntityCollection) => {
 	if ("Exit" in collection && collection.Exit !== undefined) {
 		await publishExit(collection.Exit);
 	}
+	if ("InventoryItem" in collection && collection.InventoryItem !== undefined) {
+		await publishInventoryItem(collection.InventoryItem);
+	}
 	if ("ChildToParent" in collection && collection.ChildToParent !== undefined) {
 		await publishChildToParent(collection.ChildToParent);
 	}
@@ -158,6 +163,24 @@ const publishExit = async (exit: Exit) => {
 	await dispatchDesignerCall("create_exit", [exitData]);
 };
 
+const publishInventoryItem = async (inventoryItem: InventoryItem) => {
+	const inventoryItemData = [
+		num.toBigInt(inventoryItem.inst.toString()),
+		inventoryItem.is_inventory_item,
+		num.toBigInt(inventoryItem.owner_id),
+		inventoryItem.can_be_picked_up,
+		inventoryItem.can_go_in_container,
+		inventoryItem.action_map.length > 0
+			? inventoryItem.action_map.map((x) => [
+					byteArray.byteArrayFromString(x.action),
+					0,
+					toEnumIndex(x.action_fn, inventoryItemActions),
+			  ])
+			: 0,
+	];
+	await dispatchDesignerCall("create_inventory_item", [inventoryItemData]);
+};
+
 const publishChildToParent = async (childToParent: ChildToParent) => {
 	const childToParentData = [
 		num.toBigInt(childToParent.inst.toString()),
@@ -194,6 +217,11 @@ const deleteCollection = async (model: EntityCollection) => {
 	}
 	if ("Exit" in model && model.Exit !== undefined) {
 		await dispatchDesignerCall("delete_exit", [num.toBigInt(model.Exit!.inst)]);
+	}
+	if ("InventoryItem" in model && model.InventoryItem !== undefined) {
+		await dispatchDesignerCall("delete_inventory_item", [
+			num.toBigInt(model.InventoryItem!.inst),
+		]);
 	}
 	if ("ChildToParent" in model && model.ChildToParent !== undefined) {
 		await dispatchDesignerCall("delete_child", [

--- a/packages/client/src/editor/publisher.ts
+++ b/packages/client/src/editor/publisher.ts
@@ -193,9 +193,6 @@ const publishContainer = async (container: Container) => {
 		container.can_receive_items,
 		container.is_open,
 		container.num_slots,
-		container.item_ids.length > 0
-			? container.item_ids.map((x) => num.toBigInt(x))
-			: 0,
 		container.action_map.length > 0
 			? container.action_map.map((x) => [
 					byteArray.byteArrayFromString(x.action),

--- a/packages/client/src/editor/publisher.ts
+++ b/packages/client/src/editor/publisher.ts
@@ -192,7 +192,7 @@ const publishContainer = async (container: Container) => {
 		container.can_be_opened,
 		container.can_receive_items,
 		container.is_open,
-		container.num_slots,
+		num.toBigInt(container.num_slots.toString()),
 		container.action_map.length > 0
 			? container.action_map.map((x) => [
 					byteArray.byteArrayFromString(x.action),

--- a/packages/client/src/lib/dojo_bindings/typescript/contracts.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/contracts.gen.ts
@@ -109,6 +109,27 @@ export function setupWorld(provider: DojoProvider) {
 		}
 	};
 
+	const build_designer_createInventoryItem_calldata = (t: Array<InventoryItem>): DojoCall => {
+		return {
+			contractName: "designer",
+			entrypoint: "create_inventory_item",
+			calldata: [t],
+		};
+	};
+
+	const designer_createInventoryItem = async (snAccount: Account | AccountInterface, t: Array<InventoryItem>) => {
+		try {
+			return await provider.execute(
+				snAccount,
+				build_designer_createInventoryItem_calldata(t),
+				"lore",
+			);
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
 	const build_designer_createParent_calldata = (t: Array<ParentToChildren>): DojoCall => {
 		return {
 			contractName: "designer",
@@ -235,6 +256,27 @@ export function setupWorld(provider: DojoProvider) {
 		}
 	};
 
+	const build_designer_deleteInventoryItem_calldata = (ids: Array<BigNumberish>): DojoCall => {
+		return {
+			contractName: "designer",
+			entrypoint: "delete_inventory_item",
+			calldata: [ids],
+		};
+	};
+
+	const designer_deleteInventoryItem = async (snAccount: Account | AccountInterface, ids: Array<BigNumberish>) => {
+		try {
+			return await provider.execute(
+				snAccount,
+				build_designer_deleteInventoryItem_calldata(ids),
+				"lore",
+			);
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
 	const build_designer_deleteParent_calldata = (ids: Array<BigNumberish>): DojoCall => {
 		return {
 			contractName: "designer",
@@ -291,6 +333,8 @@ export function setupWorld(provider: DojoProvider) {
 			buildCreateExitCalldata: build_designer_createExit_calldata,
 			createInspectable: designer_createInspectable,
 			buildCreateInspectableCalldata: build_designer_createInspectable_calldata,
+			createInventoryItem: designer_createInventoryItem,
+			buildCreateInventoryItemCalldata: build_designer_createInventoryItem_calldata,
 			createParent: designer_createParent,
 			buildCreateParentCalldata: build_designer_createParent_calldata,
 			deleteArea: designer_deleteArea,
@@ -303,6 +347,8 @@ export function setupWorld(provider: DojoProvider) {
 			buildDeleteExitCalldata: build_designer_deleteExit_calldata,
 			deleteInspectable: designer_deleteInspectable,
 			buildDeleteInspectableCalldata: build_designer_deleteInspectable_calldata,
+			deleteInventoryItem: designer_deleteInventoryItem,
+			buildDeleteInventoryItemCalldata: build_designer_deleteInventoryItem_calldata,
 			deleteParent: designer_deleteParent,
 			buildDeleteParentCalldata: build_designer_deleteParent_calldata,
 		},

--- a/packages/client/src/lib/dojo_bindings/typescript/contracts.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/contracts.gen.ts
@@ -46,6 +46,27 @@ export function setupWorld(provider: DojoProvider) {
 		}
 	};
 
+	const build_designer_createContainer_calldata = (t: Array<Container>): DojoCall => {
+		return {
+			contractName: "designer",
+			entrypoint: "create_container",
+			calldata: [t],
+		};
+	};
+
+	const designer_createContainer = async (snAccount: Account | AccountInterface, t: Array<Container>) => {
+		try {
+			return await provider.execute(
+				snAccount,
+				build_designer_createContainer_calldata(t),
+				"lore",
+			);
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
 	const build_designer_createEntity_calldata = (t: Array<Entity>): DojoCall => {
 		return {
 			contractName: "designer",
@@ -193,6 +214,27 @@ export function setupWorld(provider: DojoProvider) {
 		}
 	};
 
+	const build_designer_deleteContainer_calldata = (ids: Array<BigNumberish>): DojoCall => {
+		return {
+			contractName: "designer",
+			entrypoint: "delete_container",
+			calldata: [ids],
+		};
+	};
+
+	const designer_deleteContainer = async (snAccount: Account | AccountInterface, ids: Array<BigNumberish>) => {
+		try {
+			return await provider.execute(
+				snAccount,
+				build_designer_deleteContainer_calldata(ids),
+				"lore",
+			);
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
 	const build_designer_deleteEntity_calldata = (ids: Array<BigNumberish>): DojoCall => {
 		return {
 			contractName: "designer",
@@ -327,6 +369,8 @@ export function setupWorld(provider: DojoProvider) {
 			buildCreateAreaCalldata: build_designer_createArea_calldata,
 			createChild: designer_createChild,
 			buildCreateChildCalldata: build_designer_createChild_calldata,
+			createContainer: designer_createContainer,
+			buildCreateContainerCalldata: build_designer_createContainer_calldata,
 			createEntity: designer_createEntity,
 			buildCreateEntityCalldata: build_designer_createEntity_calldata,
 			createExit: designer_createExit,
@@ -341,6 +385,8 @@ export function setupWorld(provider: DojoProvider) {
 			buildDeleteAreaCalldata: build_designer_deleteArea_calldata,
 			deleteChild: designer_deleteChild,
 			buildDeleteChildCalldata: build_designer_deleteChild_calldata,
+			deleteContainer: designer_deleteContainer,
+			buildDeleteContainerCalldata: build_designer_deleteContainer_calldata,
 			deleteEntity: designer_deleteEntity,
 			buildDeleteEntityCalldata: build_designer_deleteEntity_calldata,
 			deleteExit: designer_deleteExit,

--- a/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
@@ -17,21 +17,25 @@ export interface AreaValue {
 export interface Container {
 	inst: BigNumberish;
 	is_container: boolean;
+	childToParent: ChildToParent;
 	can_be_opened: boolean;
 	can_receive_items: boolean;
 	is_open: boolean;
 	num_slots: BigNumberish;
 	item_ids: Array<BigNumberish>;
+	action_map: Array<string>;
 }
 
 // Type definition for `lore::components::container::ContainerValue` struct
 export interface ContainerValue {
 	is_container: boolean;
+	childToParent: ChildToParent;
 	can_be_opened: boolean;
 	can_receive_items: boolean;
 	is_open: boolean;
 	num_slots: BigNumberish;
 	item_ids: Array<BigNumberish>;
+	action_map: Array<string>;
 }
 
 // Type definition for `lore::components::exit::ActionMapExit` struct
@@ -271,19 +275,23 @@ export const schema: SchemaType = {
 		Container: {
 			inst: 0,
 			is_container: false,
+		childToParent: { inst: 0, is_child: false, parent: 0, },
 			can_be_opened: false,
 			can_receive_items: false,
 			is_open: false,
 			num_slots: 0,
 			item_ids: [0],
+			action_map: [""],
 		},
 		ContainerValue: {
 			is_container: false,
+		childToParent: { inst: 0, is_child: false, parent: 0, },
 			can_be_opened: false,
 			can_receive_items: false,
 			is_open: false,
 			num_slots: 0,
 			item_ids: [0],
+			action_map: [""],
 		},
 		ActionMapExit: {
 		action: "",

--- a/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
@@ -28,7 +28,6 @@ export interface Container {
 	can_receive_items: boolean;
 	is_open: boolean;
 	num_slots: BigNumberish;
-	item_ids: Array<BigNumberish>;
 	action_map: Array<ActionMapContainer>;
 }
 
@@ -39,7 +38,6 @@ export interface ContainerValue {
 	can_receive_items: boolean;
 	is_open: boolean;
 	num_slots: BigNumberish;
-	item_ids: Array<BigNumberish>;
 	action_map: Array<ActionMapContainer>;
 }
 
@@ -230,6 +228,9 @@ export type InspectableActionsEnum = CairoCustomEnum;
 // Type definition for `lore::components::inventoryItem::InventoryItemActions` enum
 export const inventoryItemActions = [
 	'UseItem',
+	'PickupItem',
+	'DropItem',
+	'PutItem',
 ] as const;
 export type InventoryItemActions = { [key in typeof inventoryItemActions[number]]: string };
 export type InventoryItemActionsEnum = CairoCustomEnum;
@@ -317,7 +318,6 @@ export const schema: SchemaType = {
 			can_receive_items: false,
 			is_open: false,
 			num_slots: 0,
-			item_ids: [0],
 			action_map: [{ action: "", inst: 0, action_fn: new CairoCustomEnum({ 
 					Open: "",
 				Close: undefined, }), }],
@@ -328,7 +328,6 @@ export const schema: SchemaType = {
 			can_receive_items: false,
 			is_open: false,
 			num_slots: 0,
-			item_ids: [0],
 			action_map: [{ action: "", inst: 0, action_fn: new CairoCustomEnum({ 
 					Open: "",
 				Close: undefined, }), }],
@@ -401,7 +400,10 @@ export const schema: SchemaType = {
 		action: "",
 			inst: 0,
 		action_fn: new CairoCustomEnum({ 
-					UseItem: "", }),
+					UseItem: "",
+				PickupItem: undefined,
+				DropItem: undefined,
+				PutItem: undefined, }),
 		},
 		InventoryItem: {
 			inst: 0,
@@ -410,7 +412,10 @@ export const schema: SchemaType = {
 			can_be_picked_up: false,
 			can_go_in_container: false,
 			action_map: [{ action: "", inst: 0, action_fn: new CairoCustomEnum({ 
-					UseItem: "", }), }],
+					UseItem: "",
+				PickupItem: undefined,
+				DropItem: undefined,
+				PutItem: undefined, }), }],
 		},
 		InventoryItemValue: {
 			is_inventory_item: false,
@@ -418,7 +423,10 @@ export const schema: SchemaType = {
 			can_be_picked_up: false,
 			can_go_in_container: false,
 			action_map: [{ action: "", inst: 0, action_fn: new CairoCustomEnum({ 
-					UseItem: "", }), }],
+					UseItem: "",
+				PickupItem: undefined,
+				DropItem: undefined,
+				PutItem: undefined, }), }],
 		},
 		Player: {
 			inst: 0,

--- a/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
@@ -88,6 +88,13 @@ export interface InspectableValue {
 	action_map: Array<ActionMapInspectable>;
 }
 
+// Type definition for `lore::components::inventoryItem::ActionMapInventoryItem` struct
+export interface ActionMapInventoryItem {
+	action: string;
+	inst: BigNumberish;
+	action_fn: InventoryItemActionsEnum;
+}
+
 // Type definition for `lore::components::inventoryItem::InventoryItem` struct
 export interface InventoryItem {
 	inst: BigNumberish;
@@ -95,6 +102,7 @@ export interface InventoryItem {
 	owner_id: BigNumberish;
 	can_be_picked_up: boolean;
 	can_go_in_container: boolean;
+	action_map: Array<ActionMapInventoryItem>;
 }
 
 // Type definition for `lore::components::inventoryItem::InventoryItemValue` struct
@@ -103,6 +111,7 @@ export interface InventoryItemValue {
 	owner_id: BigNumberish;
 	can_be_picked_up: boolean;
 	can_go_in_container: boolean;
+	action_map: Array<ActionMapInventoryItem>;
 }
 
 // Type definition for `lore::components::player::Player` struct
@@ -205,6 +214,13 @@ export const inspectableActions = [
 export type InspectableActions = { [key in typeof inspectableActions[number]]: string };
 export type InspectableActionsEnum = CairoCustomEnum;
 
+// Type definition for `lore::components::inventoryItem::InventoryItemActions` enum
+export const inventoryItemActions = [
+	'UseItem',
+] as const;
+export type InventoryItemActions = { [key in typeof inventoryItemActions[number]]: string };
+export type InventoryItemActionsEnum = CairoCustomEnum;
+
 // Type definition for `lore::constants::constants::Direction` enum
 export const direction = [
 	'None',
@@ -247,6 +263,7 @@ export interface SchemaType extends ISchemaType {
 		ActionMapInspectable: ActionMapInspectable,
 		Inspectable: Inspectable,
 		InspectableValue: InspectableValue,
+		ActionMapInventoryItem: ActionMapInventoryItem,
 		InventoryItem: InventoryItem,
 		InventoryItemValue: InventoryItemValue,
 		Player: Player,
@@ -357,18 +374,28 @@ export const schema: SchemaType = {
 				ReadRandomDescription: undefined,
 				ReadFirstDescription: undefined, }), }],
 		},
+		ActionMapInventoryItem: {
+		action: "",
+			inst: 0,
+		action_fn: new CairoCustomEnum({ 
+					UseItem: "", }),
+		},
 		InventoryItem: {
 			inst: 0,
 			is_inventory_item: false,
 			owner_id: 0,
 			can_be_picked_up: false,
 			can_go_in_container: false,
+			action_map: [{ action: "", inst: 0, action_fn: new CairoCustomEnum({ 
+					UseItem: "", }), }],
 		},
 		InventoryItemValue: {
 			is_inventory_item: false,
 			owner_id: 0,
 			can_be_picked_up: false,
 			can_go_in_container: false,
+			action_map: [{ action: "", inst: 0, action_fn: new CairoCustomEnum({ 
+					UseItem: "", }), }],
 		},
 		Player: {
 			inst: 0,
@@ -467,7 +494,9 @@ export enum ModelsMapping {
 	Inspectable = 'lore-Inspectable',
 	InspectableActions = 'lore-InspectableActions',
 	InspectableValue = 'lore-InspectableValue',
+	ActionMapInventoryItem = 'lore-ActionMapInventoryItem',
 	InventoryItem = 'lore-InventoryItem',
+	InventoryItemActions = 'lore-InventoryItemActions',
 	InventoryItemValue = 'lore-InventoryItemValue',
 	Player = 'lore-Player',
 	PlayerStory = 'lore-PlayerStory',

--- a/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
@@ -13,29 +13,34 @@ export interface AreaValue {
 	is_area: boolean;
 }
 
+// Type definition for `lore::components::container::ActionMapContainer` struct
+export interface ActionMapContainer {
+	action: string;
+	inst: BigNumberish;
+	action_fn: ContainerActionsEnum;
+}
+
 // Type definition for `lore::components::container::Container` struct
 export interface Container {
 	inst: BigNumberish;
 	is_container: boolean;
-	childToParent: ChildToParent;
 	can_be_opened: boolean;
 	can_receive_items: boolean;
 	is_open: boolean;
 	num_slots: BigNumberish;
 	item_ids: Array<BigNumberish>;
-	action_map: Array<string>;
+	action_map: Array<ActionMapContainer>;
 }
 
 // Type definition for `lore::components::container::ContainerValue` struct
 export interface ContainerValue {
 	is_container: boolean;
-	childToParent: ChildToParent;
 	can_be_opened: boolean;
 	can_receive_items: boolean;
 	is_open: boolean;
 	num_slots: BigNumberish;
 	item_ids: Array<BigNumberish>;
-	action_map: Array<string>;
+	action_map: Array<ActionMapContainer>;
 }
 
 // Type definition for `lore::components::exit::ActionMapExit` struct
@@ -198,6 +203,14 @@ export interface ParentToChildrenValue {
 	children: Array<BigNumberish>;
 }
 
+// Type definition for `lore::components::container::ContainerActions` enum
+export const containerActions = [
+	'Open',
+	'Close',
+] as const;
+export type ContainerActions = { [key in typeof containerActions[number]]: string };
+export type ContainerActionsEnum = CairoCustomEnum;
+
 // Type definition for `lore::components::exit::ExitActions` enum
 export const exitActions = [
 	'UseExit',
@@ -255,6 +268,7 @@ export interface SchemaType extends ISchemaType {
 	lore: {
 		Area: Area,
 		AreaValue: AreaValue,
+		ActionMapContainer: ActionMapContainer,
 		Container: Container,
 		ContainerValue: ContainerValue,
 		ActionMapExit: ActionMapExit,
@@ -289,26 +303,35 @@ export const schema: SchemaType = {
 		AreaValue: {
 			is_area: false,
 		},
+		ActionMapContainer: {
+		action: "",
+			inst: 0,
+		action_fn: new CairoCustomEnum({ 
+					Open: "",
+				Close: undefined, }),
+		},
 		Container: {
 			inst: 0,
 			is_container: false,
-		childToParent: { inst: 0, is_child: false, parent: 0, },
 			can_be_opened: false,
 			can_receive_items: false,
 			is_open: false,
 			num_slots: 0,
 			item_ids: [0],
-			action_map: [""],
+			action_map: [{ action: "", inst: 0, action_fn: new CairoCustomEnum({ 
+					Open: "",
+				Close: undefined, }), }],
 		},
 		ContainerValue: {
 			is_container: false,
-		childToParent: { inst: 0, is_child: false, parent: 0, },
 			can_be_opened: false,
 			can_receive_items: false,
 			is_open: false,
 			num_slots: 0,
 			item_ids: [0],
-			action_map: [""],
+			action_map: [{ action: "", inst: 0, action_fn: new CairoCustomEnum({ 
+					Open: "",
+				Close: undefined, }), }],
 		},
 		ActionMapExit: {
 		action: "",
@@ -484,7 +507,9 @@ export const schema: SchemaType = {
 export enum ModelsMapping {
 	Area = 'lore-Area',
 	AreaValue = 'lore-AreaValue',
+	ActionMapContainer = 'lore-ActionMapContainer',
 	Container = 'lore-Container',
+	ContainerActions = 'lore-ContainerActions',
 	ContainerValue = 'lore-ContainerValue',
 	ActionMapExit = 'lore-ActionMapExit',
 	Exit = 'lore-Exit',

--- a/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
@@ -205,6 +205,7 @@ export interface ParentToChildrenValue {
 export const containerActions = [
 	'Open',
 	'Close',
+	'Check',
 ] as const;
 export type ContainerActions = { [key in typeof containerActions[number]]: string };
 export type ContainerActionsEnum = CairoCustomEnum;
@@ -309,7 +310,8 @@ export const schema: SchemaType = {
 			inst: 0,
 		action_fn: new CairoCustomEnum({ 
 					Open: "",
-				Close: undefined, }),
+				Close: undefined,
+				Check: undefined, }),
 		},
 		Container: {
 			inst: 0,
@@ -320,7 +322,8 @@ export const schema: SchemaType = {
 			num_slots: 0,
 			action_map: [{ action: "", inst: 0, action_fn: new CairoCustomEnum({ 
 					Open: "",
-				Close: undefined, }), }],
+				Close: undefined,
+				Check: undefined, }), }],
 		},
 		ContainerValue: {
 			is_container: false,
@@ -330,7 +333,8 @@ export const schema: SchemaType = {
 			num_slots: 0,
 			action_map: [{ action: "", inst: 0, action_fn: new CairoCustomEnum({ 
 					Open: "",
-				Close: undefined, }), }],
+				Close: undefined,
+				Check: undefined, }), }],
 		},
 		ActionMapExit: {
 		action: "",

--- a/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
@@ -232,6 +232,7 @@ export const inventoryItemActions = [
 	'PickupItem',
 	'DropItem',
 	'PutItem',
+	'TakeOutItem',
 ] as const;
 export type InventoryItemActions = { [key in typeof inventoryItemActions[number]]: string };
 export type InventoryItemActionsEnum = CairoCustomEnum;
@@ -407,7 +408,8 @@ export const schema: SchemaType = {
 					UseItem: "",
 				PickupItem: undefined,
 				DropItem: undefined,
-				PutItem: undefined, }),
+				PutItem: undefined,
+				TakeOutItem: undefined, }),
 		},
 		InventoryItem: {
 			inst: 0,
@@ -419,7 +421,8 @@ export const schema: SchemaType = {
 					UseItem: "",
 				PickupItem: undefined,
 				DropItem: undefined,
-				PutItem: undefined, }), }],
+				PutItem: undefined,
+				TakeOutItem: undefined, }), }],
 		},
 		InventoryItemValue: {
 			is_inventory_item: false,
@@ -430,7 +433,8 @@ export const schema: SchemaType = {
 					UseItem: "",
 				PickupItem: undefined,
 				DropItem: undefined,
-				PutItem: undefined, }), }],
+				PutItem: undefined,
+				TakeOutItem: undefined, }), }],
 		},
 		Player: {
 			inst: 0,

--- a/packages/client/src/lib/systemCalls.ts
+++ b/packages/client/src/lib/systemCalls.ts
@@ -53,6 +53,7 @@ export type DesignerCall =
 	| "create_area"
 	| "create_exit"
 	| "create_inventory_item"
+	| "create_container"
 	| "create_parent"
 	| "create_child"
 	| "delete_entity"
@@ -60,6 +61,7 @@ export type DesignerCall =
 	| "delete_area"
 	| "delete_exit"
 	| "delete_inventory_item"
+	| "delete_container"
 	| "delete_parent"
 	| "delete_child";
 

--- a/packages/client/src/lib/systemCalls.ts
+++ b/packages/client/src/lib/systemCalls.ts
@@ -52,12 +52,14 @@ export type DesignerCall =
 	| "create_inspectable"
 	| "create_area"
 	| "create_exit"
+	| "create_inventory_item"
 	| "create_parent"
 	| "create_child"
 	| "delete_entity"
 	| "delete_inspectable"
 	| "delete_area"
 	| "delete_exit"
+	| "delete_inventory_item"
 	| "delete_parent"
 	| "delete_child";
 

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -1895,8 +1895,8 @@
       ]
     },
     {
-      "address": "0x5a44b7d7e1afbf1073a9701bbf4110c212712fea9dbe04e96032c674a341505",
-      "class_hash": "0x5c995c12fae5be772dcf55cf9ee0fd79569e23f947e090fd701a0d3c8f4060e",
+      "address": "0x3c24eed7bff22a3f671191d7dfc619ba9f49c5610435b9410f8cbd4998087f3",
+      "class_hash": "0x30258a8ff39e4ecd5eb9a7a6166855706bd8aaae4d98a5f8e000c148af9ed6",
       "abi": [
         {
           "type": "impl",

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -2087,8 +2087,8 @@
       ]
     },
     {
-      "address": "0x12070fca7267224e8e61d2a884423ae5c410732a82f586dce6186875ff8d243",
-      "class_hash": "0x35427fb59006b70ef11cc32f6a408e2fd71a310896ed78f1f0ae0a70bc80d07",
+      "address": "0x5382ca76683cdd15c635fb1f387842990c59b398f6fd6f93a896b01e2599d5b",
+      "class_hash": "0x7be4bca3fb2dcf53f966a5d49362e6e0d7a2cdd7620508cbdcf5c01e818f4ea",
       "abi": [
         {
           "type": "impl",

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -1312,8 +1312,8 @@
   },
   "contracts": [
     {
-      "address": "0x523117319f70748d7bdd6cf0aa663f00f700bacf9df7c6a3b41ad86e4f63c6e",
-      "class_hash": "0x808d8a4f05704ce3223e18c4d46878860be317468d60df3d3cdcf92a447295",
+      "address": "0x640edf55a7ae5d0b5eeb8959bd21412962661a799bb34493c046488c73edc5e",
+      "class_hash": "0x2315b04aee805e08cff5572d22b8bee6834edf1666b6c65338a34b709e1b8b7",
       "abi": [
         {
           "type": "impl",
@@ -1592,6 +1592,10 @@
             },
             {
               "name": "PutItem",
+              "type": "()"
+            },
+            {
+              "name": "TakeOutItem",
               "type": "()"
             }
           ]
@@ -2087,8 +2091,8 @@
       ]
     },
     {
-      "address": "0x5382ca76683cdd15c635fb1f387842990c59b398f6fd6f93a896b01e2599d5b",
-      "class_hash": "0x7be4bca3fb2dcf53f966a5d49362e6e0d7a2cdd7620508cbdcf5c01e818f4ea",
+      "address": "0x515e7a4bdd5c617e5d0d42dad62310af20bea2ab2bacd4cc15d41a81b8f24da",
+      "class_hash": "0x5016cf61ae7621dc0f4672acc048e32ed81faac314ae626eeb769f19362f8a3",
       "abi": [
         {
           "type": "impl",
@@ -2333,7 +2337,7 @@
     },
     {
       "members": [],
-      "class_hash": "0xb1d5e47eaddad6330fb49b9842918c4db3a22d4c4e24ad832454ffbc57ee0f",
+      "class_hash": "0x13870d1f7668b288a91e45b6f7b534d7cffc36a73dae927673a57706fc43e6d",
       "tag": "lore-InventoryItem",
       "selector": "0x39dcb7f28daa7084ab53831eef53e661b8c314a425a0ba7339156aa825e3606"
     },

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -1312,8 +1312,8 @@
   },
   "contracts": [
     {
-      "address": "0x70673fa6d685db3c4ce7c9e511f2c48340e015948e62bc34c8deac86bc33ec1",
-      "class_hash": "0x5b63aceec358d53a704e109c1e46c254f049fa5dde30d8e4365855dddcd6a39",
+      "address": "0x625e2dfc6929b68d6b94c33044c5c9fce07a3bc61021d0b760333f10c975882",
+      "class_hash": "0x1ab253ef9c541f009801455f564fcc1a6b9b01d9623eaf17012390e339289c3",
       "abi": [
         {
           "type": "impl",
@@ -1633,6 +1633,76 @@
           ]
         },
         {
+          "type": "enum",
+          "name": "lore::components::container::ContainerActions",
+          "variants": [
+            {
+              "name": "Open",
+              "type": "()"
+            },
+            {
+              "name": "Close",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "lore::components::container::ActionMapContainer",
+          "members": [
+            {
+              "name": "action",
+              "type": "core::byte_array::ByteArray"
+            },
+            {
+              "name": "inst",
+              "type": "core::felt252"
+            },
+            {
+              "name": "action_fn",
+              "type": "lore::components::container::ContainerActions"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "lore::components::container::Container",
+          "members": [
+            {
+              "name": "inst",
+              "type": "core::felt252"
+            },
+            {
+              "name": "is_container",
+              "type": "core::bool"
+            },
+            {
+              "name": "can_be_opened",
+              "type": "core::bool"
+            },
+            {
+              "name": "can_receive_items",
+              "type": "core::bool"
+            },
+            {
+              "name": "is_open",
+              "type": "core::bool"
+            },
+            {
+              "name": "num_slots",
+              "type": "core::integer::u32"
+            },
+            {
+              "name": "item_ids",
+              "type": "core::array::Array::<core::felt252>"
+            },
+            {
+              "name": "action_map",
+              "type": "core::array::Array::<lore::components::container::ActionMapContainer>"
+            }
+          ]
+        },
+        {
           "type": "struct",
           "name": "lore::lib::relations::ParentToChildren",
           "members": [
@@ -1734,6 +1804,18 @@
             },
             {
               "type": "function",
+              "name": "create_container",
+              "inputs": [
+                {
+                  "name": "t",
+                  "type": "core::array::Array::<lore::components::container::Container>"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
               "name": "create_parent",
               "inputs": [
                 {
@@ -1807,6 +1889,18 @@
             {
               "type": "function",
               "name": "delete_inventory_item",
+              "inputs": [
+                {
+                  "name": "ids",
+                  "type": "core::array::Array::<core::felt252>"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "delete_container",
               "inputs": [
                 {
                   "name": "ids",
@@ -1966,6 +2060,7 @@
         "create_area",
         "create_exit",
         "create_inventory_item",
+        "create_container",
         "create_parent",
         "create_child",
         "delete_entity",
@@ -1973,14 +2068,15 @@
         "delete_area",
         "delete_exit",
         "delete_inventory_item",
+        "delete_container",
         "delete_parent",
         "delete_child",
         "upgrade"
       ]
     },
     {
-      "address": "0x2dc6115198d4b3b2deb0433050920309881f453c42176982392a56e9102a041",
-      "class_hash": "0x30258a8ff39e4ecd5eb9a7a6166855706bd8aaae4d98a5f8e000c148af9ed6",
+      "address": "0x260ac18e552cdea81d9e8a77f284456efb27289e612f6974ba3321a7e12cacb",
+      "class_hash": "0x4fdea007019f018cc12760fc7473e577ef381e894e171231ff136a2d7b5eed6",
       "abi": [
         {
           "type": "impl",
@@ -2195,7 +2291,7 @@
     },
     {
       "members": [],
-      "class_hash": "0xbd2abf3a995b3f06e5517500675a59ac24ace2e98a5bfe34bb41457deae161",
+      "class_hash": "0x317f388617b86d9eb0f53023496bf0966a165e836c0f962dfba1f0d2870ff91",
       "tag": "lore-Container",
       "selector": "0x65216593d0c7b5ff416ba9bc0773cb0ffe2729720b2de66dc4613e1a9e26662"
     },

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -1895,8 +1895,8 @@
       ]
     },
     {
-      "address": "0x17850cd85366ed8f2a021427e4c4ca733742b0cb55c7ef3e2420e4001273125",
-      "class_hash": "0x5d8b84f7f8aa088be39f9f855d79898988593a624d287aee3a66945453d1d2c",
+      "address": "0x5a44b7d7e1afbf1073a9701bbf4110c212712fea9dbe04e96032c674a341505",
+      "class_hash": "0x5fca3c79a4213783b1d08cab2f09e36acc591ff0d61c385acef840d9ae34c3",
       "abi": [
         {
           "type": "impl",
@@ -2111,7 +2111,7 @@
     },
     {
       "members": [],
-      "class_hash": "0x6e0dc43043f988133beb22289af4a2e9d231bdd0848b949804be6764acfec68",
+      "class_hash": "0xbd2abf3a995b3f06e5517500675a59ac24ace2e98a5bfe34bb41457deae161",
       "tag": "lore-Container",
       "selector": "0x65216593d0c7b5ff416ba9bc0773cb0ffe2729720b2de66dc4613e1a9e26662"
     },
@@ -2141,7 +2141,7 @@
     },
     {
       "members": [],
-      "class_hash": "0x60d71a6bc97268525f5a9b1903babfffa702c98dde5bc10c9877042da2087a5",
+      "class_hash": "0x1006933725831fd238f590627ab295e4331f87efa827e9f53a037156a0df949",
       "tag": "lore-InventoryItem",
       "selector": "0x39dcb7f28daa7084ab53831eef53e661b8c314a425a0ba7339156aa825e3606"
     },

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -2084,7 +2084,7 @@
     },
     {
       "address": "0x5282b6c6b5724209ae9b67b48dd90d2ddc40e5245d84f6ce03a9e7ef3e52596",
-      "class_hash": "0x436d29b1d18080070ce7e3c013f672da6ece5316fdd963116474a6edea8014e",
+      "class_hash": "0xcd6447163494a380011088b0f643ea586b8732f4d0d3f5bf03fff7b3a07970",
       "abi": [
         {
           "type": "impl",

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -1312,8 +1312,8 @@
   },
   "contracts": [
     {
-      "address": "0x71fdc51063cbafa6eae1a5154057a769f1b6e2e9a30bbf847e000a885f427e1",
-      "class_hash": "0x487aef42da765575f97abd01baa443daa1f4490da84623e273f0b3d4c191649",
+      "address": "0x70673fa6d685db3c4ce7c9e511f2c48340e015948e62bc34c8deac86bc33ec1",
+      "class_hash": "0x5b63aceec358d53a704e109c1e46c254f049fa5dde30d8e4365855dddcd6a39",
       "abi": [
         {
           "type": "impl",
@@ -1575,6 +1575,64 @@
           ]
         },
         {
+          "type": "enum",
+          "name": "lore::components::inventoryItem::InventoryItemActions",
+          "variants": [
+            {
+              "name": "UseItem",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "lore::components::inventoryItem::ActionMapInventoryItem",
+          "members": [
+            {
+              "name": "action",
+              "type": "core::byte_array::ByteArray"
+            },
+            {
+              "name": "inst",
+              "type": "core::felt252"
+            },
+            {
+              "name": "action_fn",
+              "type": "lore::components::inventoryItem::InventoryItemActions"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "lore::components::inventoryItem::InventoryItem",
+          "members": [
+            {
+              "name": "inst",
+              "type": "core::felt252"
+            },
+            {
+              "name": "is_inventory_item",
+              "type": "core::bool"
+            },
+            {
+              "name": "owner_id",
+              "type": "core::felt252"
+            },
+            {
+              "name": "can_be_picked_up",
+              "type": "core::bool"
+            },
+            {
+              "name": "can_go_in_container",
+              "type": "core::bool"
+            },
+            {
+              "name": "action_map",
+              "type": "core::array::Array::<lore::components::inventoryItem::ActionMapInventoryItem>"
+            }
+          ]
+        },
+        {
           "type": "struct",
           "name": "lore::lib::relations::ParentToChildren",
           "members": [
@@ -1664,6 +1722,18 @@
             },
             {
               "type": "function",
+              "name": "create_inventory_item",
+              "inputs": [
+                {
+                  "name": "t",
+                  "type": "core::array::Array::<lore::components::inventoryItem::InventoryItem>"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
               "name": "create_parent",
               "inputs": [
                 {
@@ -1725,6 +1795,18 @@
             {
               "type": "function",
               "name": "delete_exit",
+              "inputs": [
+                {
+                  "name": "ids",
+                  "type": "core::array::Array::<core::felt252>"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "delete_inventory_item",
               "inputs": [
                 {
                   "name": "ids",
@@ -1883,19 +1965,21 @@
         "create_inspectable",
         "create_area",
         "create_exit",
+        "create_inventory_item",
         "create_parent",
         "create_child",
         "delete_entity",
         "delete_inspectable",
         "delete_area",
         "delete_exit",
+        "delete_inventory_item",
         "delete_parent",
         "delete_child",
         "upgrade"
       ]
     },
     {
-      "address": "0x3c24eed7bff22a3f671191d7dfc619ba9f49c5610435b9410f8cbd4998087f3",
+      "address": "0x2dc6115198d4b3b2deb0433050920309881f453c42176982392a56e9102a041",
       "class_hash": "0x30258a8ff39e4ecd5eb9a7a6166855706bd8aaae4d98a5f8e000c148af9ed6",
       "abi": [
         {

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -1896,7 +1896,7 @@
     },
     {
       "address": "0x5a44b7d7e1afbf1073a9701bbf4110c212712fea9dbe04e96032c674a341505",
-      "class_hash": "0x5fca3c79a4213783b1d08cab2f09e36acc591ff0d61c385acef840d9ae34c3",
+      "class_hash": "0x5c995c12fae5be772dcf55cf9ee0fd79569e23f947e090fd701a0d3c8f4060e",
       "abi": [
         {
           "type": "impl",

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -2087,8 +2087,8 @@
       ]
     },
     {
-      "address": "0x4be38c04dc47922464ee7cfe92837819ca9565cf682b9fc24b0540189a7b706",
-      "class_hash": "0x5acd909a277d798fceb4e2500902a920a14be335a7482f7b1556973fd3a1a0f",
+      "address": "0x12070fca7267224e8e61d2a884423ae5c410732a82f586dce6186875ff8d243",
+      "class_hash": "0x35427fb59006b70ef11cc32f6a408e2fd71a310896ed78f1f0ae0a70bc80d07",
       "abi": [
         {
           "type": "impl",

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -1312,8 +1312,8 @@
   },
   "contracts": [
     {
-      "address": "0x625e2dfc6929b68d6b94c33044c5c9fce07a3bc61021d0b760333f10c975882",
-      "class_hash": "0x1ab253ef9c541f009801455f564fcc1a6b9b01d9623eaf17012390e339289c3",
+      "address": "0x47e6c9a111ff3dd7e631687e5535f758fa20749d28d6063d9da35f261cacaed",
+      "class_hash": "0x41aa98721564a2319a8e7b1b305eaeb9e54746bddb1e6f93038e5bf2cec230c",
       "abi": [
         {
           "type": "impl",
@@ -1581,6 +1581,18 @@
             {
               "name": "UseItem",
               "type": "()"
+            },
+            {
+              "name": "PickupItem",
+              "type": "()"
+            },
+            {
+              "name": "DropItem",
+              "type": "()"
+            },
+            {
+              "name": "PutItem",
+              "type": "()"
             }
           ]
         },
@@ -1691,10 +1703,6 @@
             {
               "name": "num_slots",
               "type": "core::integer::u32"
-            },
-            {
-              "name": "item_ids",
-              "type": "core::array::Array::<core::felt252>"
             },
             {
               "name": "action_map",
@@ -2075,8 +2083,8 @@
       ]
     },
     {
-      "address": "0x260ac18e552cdea81d9e8a77f284456efb27289e612f6974ba3321a7e12cacb",
-      "class_hash": "0x4fdea007019f018cc12760fc7473e577ef381e894e171231ff136a2d7b5eed6",
+      "address": "0x5282b6c6b5724209ae9b67b48dd90d2ddc40e5245d84f6ce03a9e7ef3e52596",
+      "class_hash": "0x436d29b1d18080070ce7e3c013f672da6ece5316fdd963116474a6edea8014e",
       "abi": [
         {
           "type": "impl",
@@ -2291,7 +2299,7 @@
     },
     {
       "members": [],
-      "class_hash": "0x317f388617b86d9eb0f53023496bf0966a165e836c0f962dfba1f0d2870ff91",
+      "class_hash": "0x2239f8798a4060e3deadedeee28131e7ec6811d9e5d87062e296d886b13a3bf",
       "tag": "lore-Container",
       "selector": "0x65216593d0c7b5ff416ba9bc0773cb0ffe2729720b2de66dc4613e1a9e26662"
     },
@@ -2321,7 +2329,7 @@
     },
     {
       "members": [],
-      "class_hash": "0x1006933725831fd238f590627ab295e4331f87efa827e9f53a037156a0df949",
+      "class_hash": "0xb1d5e47eaddad6330fb49b9842918c4db3a22d4c4e24ad832454ffbc57ee0f",
       "tag": "lore-InventoryItem",
       "selector": "0x39dcb7f28daa7084ab53831eef53e661b8c314a425a0ba7339156aa825e3606"
     },

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -1312,8 +1312,8 @@
   },
   "contracts": [
     {
-      "address": "0x47e6c9a111ff3dd7e631687e5535f758fa20749d28d6063d9da35f261cacaed",
-      "class_hash": "0x41aa98721564a2319a8e7b1b305eaeb9e54746bddb1e6f93038e5bf2cec230c",
+      "address": "0x523117319f70748d7bdd6cf0aa663f00f700bacf9df7c6a3b41ad86e4f63c6e",
+      "class_hash": "0x808d8a4f05704ce3223e18c4d46878860be317468d60df3d3cdcf92a447295",
       "abi": [
         {
           "type": "impl",
@@ -1654,6 +1654,10 @@
             },
             {
               "name": "Close",
+              "type": "()"
+            },
+            {
+              "name": "Check",
               "type": "()"
             }
           ]
@@ -2083,8 +2087,8 @@
       ]
     },
     {
-      "address": "0x5282b6c6b5724209ae9b67b48dd90d2ddc40e5245d84f6ce03a9e7ef3e52596",
-      "class_hash": "0xcd6447163494a380011088b0f643ea586b8732f4d0d3f5bf03fff7b3a07970",
+      "address": "0x4be38c04dc47922464ee7cfe92837819ca9565cf682b9fc24b0540189a7b706",
+      "class_hash": "0x5acd909a277d798fceb4e2500902a920a14be335a7482f7b1556973fd3a1a0f",
       "abi": [
         {
           "type": "impl",
@@ -2299,7 +2303,7 @@
     },
     {
       "members": [],
-      "class_hash": "0x2239f8798a4060e3deadedeee28131e7ec6811d9e5d87062e296d886b13a3bf",
+      "class_hash": "0x284cba418a7c8300707e863894565e46595d2a28b1a9e8670d476002e9e489c",
       "tag": "lore-Container",
       "selector": "0x65216593d0c7b5ff416ba9bc0773cb0ffe2729720b2de66dc4613e1a9e26662"
     },

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -2091,8 +2091,8 @@
       ]
     },
     {
-      "address": "0x515e7a4bdd5c617e5d0d42dad62310af20bea2ab2bacd4cc15d41a81b8f24da",
-      "class_hash": "0x5016cf61ae7621dc0f4672acc048e32ed81faac314ae626eeb769f19362f8a3",
+      "address": "0x3fd9c2795c4d9c8005f8119e512a968922fbef1ff3088458bd2e035b0bd62c8",
+      "class_hash": "0x11b71fbfaa0f6c8e71087ce2126ce3864e56f0a43aca3093be475332704b87e",
       "abi": [
         {
           "type": "impl",

--- a/packages/contracts/src/components/container.cairo
+++ b/packages/contracts/src/components/container.cairo
@@ -1,3 +1,4 @@
+use super::super::lib::entity::EntityTrait;
 use dojo::{world::WorldStorage, model::ModelStorage};
 use lore::{
     constants::errors::Error, components::{inventoryItem::InventoryItem},
@@ -79,7 +80,7 @@ pub impl ContainerImpl of ContainerTrait {
 
     fn can_put_item(self: Container, world: WorldStorage, item: InventoryItem) -> bool {
         let mut can_put_item = false;
-        // chekc if container is open
+        // check if container is open
         if (!self.is_open) {
             return can_put_item;
         }
@@ -108,7 +109,7 @@ pub impl ContainerImpl of ContainerTrait {
         can_put_item
     }
 
-    fn put_item(self: Container, mut world: WorldStorage, item: InventoryItem) {
+    fn put_item_in(self: Container, mut world: WorldStorage, item: InventoryItem) {
         // get container
         let mut container: Container = world.read_model(self.inst);
 
@@ -126,8 +127,26 @@ pub impl ContainerImpl of ContainerTrait {
     }
 
 
-    fn take_item(self: Container, world: WorldStorage, item: InventoryItem) {
-        assert(true == false, 'take_item not yet implemented');
+    fn put_item_out(
+        self: Container, mut world: WorldStorage, item: InventoryItem, player: @Player,
+    ) {
+        // get container
+        let mut container: Container = world.read_model(self.inst);
+        // get item entity
+        let item_entity: Entity = world.read_model(item.inst);
+        // get room
+        let room: Entity = player.get_room(@world).unwrap();
+
+        // check if the item is in the container
+        if (!container.clone().contains(item_entity.inst, @world)) {
+            return;
+        }
+        // remove item from container:
+        // set parent to be the room's entity
+        item_entity.set_parent(world, @room);
+        //item_entity.remove_from_parent(world, @container);
+        // update container
+        world.write_model(@container);
     }
 
     fn contains(self: Container, itemID: felt252, world: @WorldStorage) -> bool {
@@ -135,7 +154,7 @@ pub impl ContainerImpl of ContainerTrait {
         // check if item is already in container
         for item_id in self.clone().get_item_ids(world) {
             if (item_id == itemID) {
-                already_inside;
+                already_inside = true;
                 break;
             }
         };

--- a/packages/contracts/src/components/container.cairo
+++ b/packages/contracts/src/components/container.cairo
@@ -158,7 +158,7 @@ pub impl ContainerImpl of ContainerTrait {
         if (!self.can_receive_items) {
             player.say(*world, ("It cannot receive items"));
         } else {
-            player.say(*world, ("Itcan receive items"));
+            player.say(*world, ("It can receive items"));
         }
         // check if container is empty
         if (self.clone().is_empty(world)) {
@@ -240,11 +240,29 @@ pub impl ContainerComponent of Component<Container> {
         let nouns = command.get_nouns();
         match action.action_fn {
             ContainerActions::Open => {
-                player.say(world, format!("You are trying to open:{:?}", nouns[0]));
+                if (self.is_open) {
+                    player
+                        .say(
+                            world,
+                            format!("The {} is already open.", self.clone().entity(@world).name),
+                        );
+                } else {
+                    player.say(world, format!("You open {}", self.clone().entity(@world).name));
+                    self.set_open(world, true);
+                }
                 return Result::Ok(());
             },
             ContainerActions::Close => {
-                player.say(world, format!("You are trying to close:{:?}", nouns[0]));
+                if (!self.is_open) {
+                    player
+                        .say(
+                            world,
+                            format!("The {} is already closed.", self.clone().entity(@world).name),
+                        );
+                } else {
+                    player.say(world, format!("You close {}", self.clone().entity(@world).name));
+                    self.set_open(world, false);
+                }
                 return Result::Ok(());
             },
             ContainerActions::Check => {

--- a/packages/contracts/src/components/container.cairo
+++ b/packages/contracts/src/components/container.cairo
@@ -91,6 +91,10 @@ pub impl ContainerImpl of ContainerTrait {
         if (!self.can_receive_items) {
             return can_put_item;
         }
+        // check if item can be picked up
+        if (!item.can_be_picked_up) {
+            return can_put_item;
+        }
         // check if item can go into the container
         if (!item.can_go_in_container) {
             return can_put_item;
@@ -142,11 +146,21 @@ pub impl ContainerImpl of ContainerTrait {
         self: Container, world: @WorldStorage, player: @Player, object: @ByteArray,
     ) -> bool {
         // check if container is open
+        // we also check if the container is the player's personal inventory
         if (!self.is_open) {
-            player.say(*world, format!("The {} is closed", object));
-            return true;
+            if (self.inst == *player.inst) {
+                player.say(*world, format!("{} personal inventory is close", object));
+                return true;
+            } else {
+                player.say(*world, format!("The {} is closed", object));
+                return true;
+            }
         } else {
-            player.say(*world, format!("The {} is open.", object));
+            if (self.inst == *player.inst) {
+                player.say(*world, format!("{} personal inventory is open", object));
+            } else {
+                player.say(*world, format!("{} is open", object));
+            }
         }
         // check if container is full
         if (self.clone().is_full(world)) {

--- a/packages/contracts/src/components/container.cairo
+++ b/packages/contracts/src/components/container.cairo
@@ -33,7 +33,6 @@ pub struct ActionMapContainer {
 
 #[derive(Serde, Copy, Drop, Introspect, PartialEq, Debug)]
 pub enum ContainerActions {
-    UseItem,
     Open,
     Close,
 }
@@ -167,9 +166,6 @@ pub impl ContainerComponent of Component<Container> {
             .action_map =
                 array![
                     ActionMapContainer {
-                        action: "use", inst: 0, action_fn: ContainerActions::UseItem,
-                    },
-                    ActionMapContainer {
                         action: "open", inst: 0, action_fn: ContainerActions::Open,
                     },
                     ActionMapContainer {
@@ -203,16 +199,6 @@ pub impl ContainerComponent of Component<Container> {
         let (action, _token) = get_action_token(@self, world, command).unwrap();
         let nouns = command.get_nouns();
         match action.action_fn {
-            ContainerActions::UseItem => {
-                player
-                    .say(
-                        world,
-                        format!("You are trying to use:{:?} that is in a container", nouns[0]),
-                    );
-                // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
-                // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
-                return Result::Ok(());
-            },
             ContainerActions::Open => {
                 player.say(world, format!("You are trying to open:{:?}", nouns[0]));
                 return Result::Ok(());

--- a/packages/contracts/src/components/container.cairo
+++ b/packages/contracts/src/components/container.cairo
@@ -1,20 +1,24 @@
 use dojo::{world::WorldStorage, model::ModelStorage};
-use lore::components::{};
-use lore::components::{inventoryItem::InventoryItem};
+use lore::{
+    components::{inventoryItem::InventoryItem},
+    lib::{entity::{Entity, EntityImpl}, relations::{ChildToParent}},
+};
 
-#[derive(Clone, Drop, Serde, Introspect, Debug)]
+#[derive(Clone, Drop, Serde, Introspect)]
 #[dojo::model]
 pub struct Container {
     #[key]
     pub inst: felt252,
     pub is_container: bool,
+    pub childToParent: ChildToParent,
     // properties
     pub can_be_opened: bool,
     pub can_receive_items: bool,
     pub is_open: bool,
     pub num_slots: u32,
     pub item_ids: Array<felt252>,
-    // pub action_map: Array<ByteArray>,
+    // pub accept_tags: Array<Tag>,
+    pub action_map: Array<ByteArray>,
 }
 
 #[generate_trait]
@@ -55,16 +59,66 @@ pub impl ContainerImpl of ContainerTrait {
     }
 
     fn can_put_item(self: Container, world: WorldStorage, item: InventoryItem) -> bool {
-        let itemAmount: u32 = self.item_ids.len().try_into().unwrap();
-        return itemAmount < self.num_slots;
+        let mut can_put_item = false;
+        // check if container is full
+        if (self.clone().is_full()) {
+            return can_put_item;
+        }
+        // check if container can receive items
+        if (!self.can_receive_items) {
+            return can_put_item;
+        }
+        // check if item can go into the container
+        if (!item.can_go_in_container) {
+            return can_put_item;
+        }
+        // check if item is already in the container
+        if (self.contains(item.inst)) {
+            return can_put_item;
+        }
+        // if checks pass, container can receive item
+        can_put_item = true;
+        can_put_item
     }
 
-    fn put_item(self: Container, world: WorldStorage, item: InventoryItem) {
-        assert(true == false, 'put_item not yet implemented');
+    fn put_item(self: Container, mut world: WorldStorage, item: InventoryItem) {
+        // get container
+        let mut container: Container = world.read_model(self.inst);
+        // get item entity
+        let item_entity: Entity = world.read_model(item.inst);
+        // check if container is full
+        if (container.clone().is_full()) {
+            return;
+        }
+        // check if item can be put in container
+        if (!container.clone().can_put_item(world, item.clone())) {
+            return;
+        }
+        // add item to container by getting the parent of the container which can be the player or a
+        // chest, etc
+        let mut container_parent: Entity = world.read_model(container.childToParent.parent);
+        // set parent to be the container_parent
+        item_entity.set_parent(world, @container_parent);
+        // add item to container
+        container.item_ids.append(item.inst);
+        // update container
+        world.write_model(@container);
     }
 
 
     fn take_item(self: Container, world: WorldStorage, item: InventoryItem) {
         assert(true == false, 'take_item not yet implemented');
+    }
+
+    fn contains(self: Container, itemID: felt252) -> bool {
+        let mut already_inside = false;
+        // check if item is already in container
+        for item_id in self.item_ids.clone() {
+            if (item_id == itemID) {
+                already_inside;
+                break;
+            }
+        };
+        already_inside
     }
 }

--- a/packages/contracts/src/components/container.cairo
+++ b/packages/contracts/src/components/container.cairo
@@ -69,39 +69,39 @@ pub impl ContainerImpl of ContainerTrait {
         world.write_model(@model);
     }
 
-    fn is_full(self: Container, world: @WorldStorage) -> bool {
+    fn is_full(self: @Container, world: @WorldStorage) -> bool {
         let itemAmount: u32 = self.clone().get_item_ids(world).len().try_into().unwrap();
-        return itemAmount >= self.num_slots;
+        return itemAmount >= *self.num_slots;
     }
 
     fn is_empty(self: Container, world: @WorldStorage) -> bool {
         return self.clone().get_item_ids(world).len() == 0;
     }
 
-    fn can_put_item(self: Container, world: WorldStorage, item: InventoryItem) -> bool {
+    fn can_put_item(self: @Container, world: @WorldStorage, item: @InventoryItem) -> bool {
         let mut can_put_item = false;
         // check if container is open
-        if (!self.is_open) {
+        if (!*self.is_open) {
             return can_put_item;
         }
         // check if container is full
-        if (self.clone().is_full(@world)) {
+        if (self.clone().is_full(world)) {
             return can_put_item;
         }
         // check if container can receive items
-        if (!self.can_receive_items) {
+        if (!*self.can_receive_items) {
             return can_put_item;
         }
         // check if item can be picked up
-        if (!item.can_be_picked_up) {
+        if (!*item.can_be_picked_up) {
             return can_put_item;
         }
         // check if item can go into the container
-        if (!item.can_go_in_container) {
+        if (!*item.can_go_in_container) {
             return can_put_item;
         }
         // check if item is already in the container
-        if (self.contains(item.inst, @world)) {
+        if (self.contains(*item.inst, world)) {
             return can_put_item;
         }
         // if checks pass, container can receive item
@@ -117,7 +117,7 @@ pub impl ContainerImpl of ContainerTrait {
         let item_entity: Entity = world.read_model(item.inst);
 
         // check if item can be put in container
-        if (!container.clone().can_put_item(world, item.clone())) {
+        if (!container.clone().can_put_item(@world, @item.clone())) {
             return;
         }
         // set parent to be the container's entity
@@ -149,7 +149,7 @@ pub impl ContainerImpl of ContainerTrait {
         world.write_model(@container);
     }
 
-    fn contains(self: Container, itemID: felt252, world: @WorldStorage) -> bool {
+    fn contains(self: @Container, itemID: felt252, world: @WorldStorage) -> bool {
         let mut already_inside = false;
         // check if item is already in container
         for item_id in self.clone().get_item_ids(world) {

--- a/packages/contracts/src/components/exit.cairo
+++ b/packages/contracts/src/components/exit.cairo
@@ -132,6 +132,10 @@ pub impl ExitComponent of Component<Exit> {
                 if (!(matchesName || matchesDirection)) {
                     return Result::Err(Error::ActionFailed);
                 }
+                // if the exit is not enterable, we can't go there
+                if (!self.clone().can_player_enter()) {
+                    return Result::Err(Error::ActionFailed);
+                }
 
                 destination_inst = self.leads_to;
                 player.clone().move_to_room(world, destination_inst);

--- a/packages/contracts/src/components/inventoryItem.cairo
+++ b/packages/contracts/src/components/inventoryItem.cairo
@@ -103,10 +103,12 @@ pub impl InventoryItemComponent of Component<InventoryItem> {
         mut self: InventoryItem, mut world: WorldStorage, player: @Player, command: @Command,
     ) -> Result<(), Error> {
         println!("InventoryItem execute_command");
+        player.say(world, format!("You are executing inventory item"));
         let (action, _token) = get_action_token(@self, world, command).unwrap();
+        let nouns = command.get_nouns();
         match action.action_fn {
             InventoryItemActions::UseItem => {
-                player.say(world, "You pick or drop the item");
+                player.say(world, format!("You are trying to pick or drop:{:?}", nouns[0]));
                 // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
                 // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
                 return Result::Ok(());

--- a/packages/contracts/src/components/inventoryItem.cairo
+++ b/packages/contracts/src/components/inventoryItem.cairo
@@ -120,25 +120,40 @@ pub impl InventoryItemComponent of Component<InventoryItem> {
             InventoryItemActions::UseItem => {
                 player.say(world, format!("You are trying to use: {}", nouns[0].text));
                 // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
-                // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
+                // LIKE USE ITEM
                 return Result::Ok(());
             },
             InventoryItemActions::PickupItem => {
                 player.say(world, format!("You are trying to pickup: {}", nouns[0].text));
-                // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
-                // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
+                // This is for the player's personal inventory container
+                // Ex: "pickup the sword"
+                let personal_container = player.get_personal_container(@world);
+                if personal_container.is_none() {
+                    return Result::Err(Error::ActionFailed);
+                }
+                let container_component: Container = personal_container.unwrap();
+                player
+                    .say(
+                        world,
+                        format!(
+                            "Personal container is: {:?}",
+                            container_component.clone().entity(@world).name,
+                        ),
+                    );
+                container_component.put_item(world, self.clone());
+
                 return Result::Ok(());
             },
             InventoryItemActions::DropItem => {
                 player.say(world, format!("You are trying to drop: {}", nouns[0].text));
                 // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
-                // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
+                // LIKE DROP ITEM
                 return Result::Ok(());
             },
             InventoryItemActions::PutItem => {
                 player.say(world, format!("You are trying to put: {}", nouns[0].text));
-                // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
-                // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
+                // This is for a specific container
+                // Ex: "put the sword in the bag"
                 // Get the player's container
                 let player_container = get_player_container(@world, player, nouns);
                 if player_container.is_none() {
@@ -174,6 +189,7 @@ fn get_action_token(
 }
 
 // @dev: wip get player's container
+// This can be the an entity container attached to the player
 fn get_player_container(
     world: @WorldStorage, player: @Player, nouns: Array<Token>,
 ) -> Option<Container> {

--- a/packages/contracts/src/components/inventoryItem.cairo
+++ b/packages/contracts/src/components/inventoryItem.cairo
@@ -1,3 +1,15 @@
+use dojo::{world::{WorldStorage}, model::ModelStorage};
+use lore::{
+    constants::errors::Error,
+    lib::{
+        entity::{Entity, EntityImpl}, a_lexer::{Command, Token, CommandImpl},
+        utils::ByteArrayTraitExt,
+    },
+    components::area::{AreaComponent},
+};
+use super::{Component, player::{Player, PlayerImpl, PlayerTrait}};
+
+
 #[derive(Clone, Drop, Serde)]
 #[dojo::model]
 pub struct InventoryItem {
@@ -8,6 +20,19 @@ pub struct InventoryItem {
     pub owner_id: felt252,
     pub can_be_picked_up: bool,
     pub can_go_in_container: bool,
+    pub action_map: Array<ActionMapInventoryItem>,
+}
+
+#[derive(Clone, Drop, Serde, Introspect, Debug)]
+pub struct ActionMapInventoryItem {
+    pub action: ByteArray,
+    pub inst: felt252,
+    pub action_fn: InventoryItemActions,
+}
+
+#[derive(Serde, Copy, Drop, Introspect, PartialEq, Debug)]
+pub enum InventoryItemActions {
+    UseItem,
 }
 
 #[generate_trait]
@@ -23,4 +48,90 @@ pub impl InventoryItemImpl of InventoryItemTrait {
     fn set_can_go_in_container(ref self: InventoryItem, can_go_in_container: bool) {
         self.can_go_in_container = can_go_in_container;
     }
+}
+
+pub impl InventoryItemComponent of Component<InventoryItem> {
+    type ComponentType = InventoryItem;
+
+    fn inst(self: @InventoryItem) -> @felt252 {
+        self.inst
+    }
+
+    fn entity(self: @InventoryItem, world: @WorldStorage) -> Entity {
+        EntityImpl::get_entity(world, self.inst).unwrap()
+    }
+
+    fn has_component(self: @InventoryItem, world: WorldStorage, inst: felt252) -> bool {
+        let inventory_item: InventoryItem = world.read_model(inst);
+        inventory_item.is_inventory_item
+    }
+
+    fn add_component(mut world: WorldStorage, inst: felt252) -> InventoryItem {
+        let mut inventory_item: InventoryItem = world.read_model(inst);
+        inventory_item.inst = inst;
+        inventory_item.is_inventory_item = true;
+        inventory_item
+            .action_map =
+                array![
+                    ActionMapInventoryItem {
+                        action: "pickup", inst: 0, action_fn: InventoryItemActions::UseItem,
+                    },
+                    ActionMapInventoryItem {
+                        action: "drop", inst: 0, action_fn: InventoryItemActions::UseItem,
+                    },
+                ];
+        inventory_item.store(world);
+        inventory_item
+    }
+
+    fn get_component(world: WorldStorage, inst: felt252) -> Option<InventoryItem> {
+        let inventory_item: InventoryItem = world.read_model(inst);
+        if (!inventory_item.has_component(world, inst)) {
+            return Option::None;
+        }
+        let inventory_item: InventoryItem = world.read_model(inst);
+        Option::Some(inventory_item)
+    }
+
+    fn can_use_command(
+        self: @InventoryItem, world: WorldStorage, player: @Player, command: @Command,
+    ) -> bool {
+        get_action_token(self, world, command).is_some()
+    }
+
+    fn execute_command(
+        mut self: InventoryItem, mut world: WorldStorage, player: @Player, command: @Command,
+    ) -> Result<(), Error> {
+        println!("InventoryItem execute_command");
+        let (action, _token) = get_action_token(@self, world, command).unwrap();
+        match action.action_fn {
+            InventoryItemActions::UseItem => {
+                player.say(world, "You pick or drop the item");
+                // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
+                // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
+                return Result::Ok(());
+            },
+        }
+        Result::Err(Error::ActionFailed)
+    }
+
+    fn store(self: @InventoryItem, mut world: WorldStorage) {
+        world.write_model(self);
+    }
+}
+
+// @dev: wip how to access tokens
+fn get_action_token(
+    self: @InventoryItem, world: WorldStorage, command: @Command,
+) -> Option<(ActionMapInventoryItem, Token)> {
+    let mut action_token: Option<(ActionMapInventoryItem, Token)> = Option::None;
+    for token in command.tokens.clone() {
+        for action in self.action_map.clone() {
+            if (token.text == action.action) {
+                action_token = Option::Some((action, token));
+                break;
+            }
+        }
+    };
+    action_token
 }

--- a/packages/contracts/src/components/inventoryItem.cairo
+++ b/packages/contracts/src/components/inventoryItem.cairo
@@ -33,6 +33,9 @@ pub struct ActionMapInventoryItem {
 #[derive(Serde, Copy, Drop, Introspect, PartialEq, Debug)]
 pub enum InventoryItemActions {
     UseItem,
+    PickupItem,
+    DropItem,
+    PutItem,
 }
 
 #[generate_trait]
@@ -74,13 +77,16 @@ pub impl InventoryItemComponent of Component<InventoryItem> {
             .action_map =
                 array![
                     ActionMapInventoryItem {
-                        action: "pickup", inst: 0, action_fn: InventoryItemActions::UseItem,
+                        action: "pickup", inst: 0, action_fn: InventoryItemActions::PickupItem,
                     },
                     ActionMapInventoryItem {
-                        action: "drop", inst: 0, action_fn: InventoryItemActions::UseItem,
+                        action: "drop", inst: 0, action_fn: InventoryItemActions::DropItem,
                     },
                     ActionMapInventoryItem {
-                        action: "put", inst: 0, action_fn: InventoryItemActions::UseItem,
+                        action: "put", inst: 0, action_fn: InventoryItemActions::PutItem,
+                    },
+                    ActionMapInventoryItem {
+                        action: "use", inst: 0, action_fn: InventoryItemActions::UseItem,
                     },
                 ];
         inventory_item.store(world);
@@ -111,7 +117,25 @@ pub impl InventoryItemComponent of Component<InventoryItem> {
         let nouns = command.get_nouns();
         match action.action_fn {
             InventoryItemActions::UseItem => {
-                player.say(world, format!("You are trying to pick or drop:{:?}", nouns[0]));
+                player.say(world, format!("You are trying to use:{:?}", nouns[0]));
+                // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
+                // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
+                return Result::Ok(());
+            },
+            InventoryItemActions::PickupItem => {
+                player.say(world, format!("You are trying to pickup:{:?}", nouns[0]));
+                // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
+                // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
+                return Result::Ok(());
+            },
+            InventoryItemActions::DropItem => {
+                player.say(world, format!("You are trying to drop:{:?}", nouns[0]));
+                // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
+                // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
+                return Result::Ok(());
+            },
+            InventoryItemActions::PutItem => {
+                player.say(world, format!("You are trying to put:{:?}", nouns[0]));
                 // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
                 // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
                 return Result::Ok(());

--- a/packages/contracts/src/components/inventoryItem.cairo
+++ b/packages/contracts/src/components/inventoryItem.cairo
@@ -79,6 +79,9 @@ pub impl InventoryItemComponent of Component<InventoryItem> {
                     ActionMapInventoryItem {
                         action: "drop", inst: 0, action_fn: InventoryItemActions::UseItem,
                     },
+                    ActionMapInventoryItem {
+                        action: "put", inst: 0, action_fn: InventoryItemActions::UseItem,
+                    },
                 ];
         inventory_item.store(world);
         inventory_item

--- a/packages/contracts/src/components/inventoryItem.cairo
+++ b/packages/contracts/src/components/inventoryItem.cairo
@@ -117,25 +117,25 @@ pub impl InventoryItemComponent of Component<InventoryItem> {
         let nouns = command.get_nouns();
         match action.action_fn {
             InventoryItemActions::UseItem => {
-                player.say(world, format!("You are trying to use:{:?}", nouns[0]));
+                player.say(world, format!("You are trying to use: {}", nouns[0].text));
                 // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
                 // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
                 return Result::Ok(());
             },
             InventoryItemActions::PickupItem => {
-                player.say(world, format!("You are trying to pickup:{:?}", nouns[0]));
+                player.say(world, format!("You are trying to pickup: {}", nouns[0].text));
                 // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
                 // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
                 return Result::Ok(());
             },
             InventoryItemActions::DropItem => {
-                player.say(world, format!("You are trying to drop:{:?}", nouns[0]));
+                player.say(world, format!("You are trying to drop: {}", nouns[0].text));
                 // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
                 // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
                 return Result::Ok(());
             },
             InventoryItemActions::PutItem => {
-                player.say(world, format!("You are trying to put:{:?}", nouns[0]));
+                player.say(world, format!("You are trying to put: {}", nouns[0].text));
                 // HERE SHOULD GO THE LOGIC FOR HANDLING THE COMMAND
                 // LIKE PUT ITEM IN CONTAINER, TAKE ITEM FROM CONTAINER, DROP ITEM, etc.
                 return Result::Ok(());

--- a/packages/contracts/src/components/player.cairo
+++ b/packages/contracts/src/components/player.cairo
@@ -4,7 +4,10 @@ use dojo::{world::WorldStorage, model::ModelStorage};
 use starknet::ContractAddress;
 use lore::{
     constants::errors::Error, lib::{entity::{EntityImpl, Entity}, a_lexer::Command},
-    components::{Component, inspectable::{Inspectable, InspectableImpl}},
+    components::{
+        Component, inspectable::{Inspectable, InspectableImpl},
+        container::{Container, ContainerComponent},
+    },
 };
 
 pub struct EntityKey {
@@ -107,6 +110,19 @@ pub impl PlayerImpl of PlayerTrait {
             },
             Option::None => array![],
         }
+    }
+
+    // Get the player personal inventory container component
+    fn get_personal_container(self: @Player, world: @WorldStorage) -> Option<Container> {
+        let mut personal_container: Option<Container> = Option::None;
+        match ContainerComponent::get_component(*world, *self.inst) {
+            Option::Some(c) => { personal_container = Option::Some(c); },
+            Option::None => {
+                personal_container = Option::None;
+                self.say(*world, format!("You don't have a personal inventory container"));
+            },
+        }
+        personal_container
     }
 }
 

--- a/packages/contracts/src/components/player.cairo
+++ b/packages/contracts/src/components/player.cairo
@@ -94,7 +94,11 @@ pub impl PlayerImpl of PlayerTrait {
                 context.append(room.clone());
                 let children = room.get_children(world);
                 for child in children.clone() {
-                    context.append(child);
+                    context.append(child.clone());
+                    let son = child.clone().get_children(world);
+                    for child_2 in son {
+                        context.append(child_2);
+                    }
                 };
                 context
             },

--- a/packages/contracts/src/components/player.cairo
+++ b/packages/contracts/src/components/player.cairo
@@ -95,9 +95,12 @@ pub impl PlayerImpl of PlayerTrait {
                 let children = room.get_children(world);
                 for child in children.clone() {
                     context.append(child.clone());
-                    let son = child.clone().get_children(world);
-                    for child_2 in son {
-                        context.append(child_2);
+                    // If child inst is equal to the one of the player, go over the children it has
+                    if (*self.inst == child.inst) {
+                        let children_2 = child.get_children(world);
+                        for child_2 in children_2 {
+                            context.append(child_2);
+                        }
                     }
                 };
                 context

--- a/packages/contracts/src/components/player.cairo
+++ b/packages/contracts/src/components/player.cairo
@@ -101,6 +101,7 @@ pub impl PlayerImpl of PlayerTrait {
                 let mut context: Array<Entity> = array![];
                 context.append(room.clone());
                 let children = room.get_children(world);
+                // Go over 1st level children
                 for child in children.clone() {
                     context.append(child.clone());
                 };
@@ -117,6 +118,7 @@ pub impl PlayerImpl of PlayerTrait {
                 let mut context: Array<Entity> = array![];
                 context.append(room.clone());
                 let children = room.get_children(world);
+                // Go over 1st level children
                 for child in children.clone() {
                     context.append(child.clone());
                     // Go over 2nd level children
@@ -129,21 +131,6 @@ pub impl PlayerImpl of PlayerTrait {
                             context.append(child_3);
                         }
                     };
-                    // // If child inst is equal to the one of the player, go over the children it
-                // has if (*self.inst == child.inst) {
-                //     let children_2 = child.get_children(world);
-                //     for child_2 in children_2 {
-                //         context.append(child_2.clone());
-                //         // If child_2 inst is equal to the one of the player, go over the
-                //         // children it has
-                //         if (*self.inst == child_2.inst) {
-                //             let children_3 = child_2.get_children(world);
-                //             for child_3 in children_3 {
-                //                 context.append(child_3);
-                //             }
-                //         }
-                //     }
-                // }
                 };
                 context
             },

--- a/packages/contracts/src/components/player.cairo
+++ b/packages/contracts/src/components/player.cairo
@@ -44,6 +44,10 @@ pub impl PlayerImpl of PlayerTrait {
         }
         self.say(world, format!("{}", room.unwrap().name));
         for item in context {
+            // Don't add the player to the description
+            if (item.inst == *self.inst) {
+                continue;
+            }
             let inspectable: Option<Inspectable> = Component::get_component(world, item.inst);
             if inspectable.is_some() {
                 let description = inspectable.unwrap().get_random_description(world);
@@ -90,6 +94,7 @@ pub impl PlayerImpl of PlayerTrait {
         parent
     }
 
+    // Get the 1st level context of the room
     fn get_context(self: @Player, world: @WorldStorage) -> Array<Entity> {
         match self.get_room(world) {
             Option::Some(room) => {
@@ -98,13 +103,47 @@ pub impl PlayerImpl of PlayerTrait {
                 let children = room.get_children(world);
                 for child in children.clone() {
                     context.append(child.clone());
-                    // If child inst is equal to the one of the player, go over the children it has
-                    if (*self.inst == child.inst) {
-                        let children_2 = child.get_children(world);
-                        for child_2 in children_2 {
-                            context.append(child_2);
+                };
+                context
+            },
+            Option::None => array![],
+        }
+    }
+
+    // Get the full context of the room
+    fn get_full_context(self: @Player, world: @WorldStorage) -> Array<Entity> {
+        match self.get_room(world) {
+            Option::Some(room) => {
+                let mut context: Array<Entity> = array![];
+                context.append(room.clone());
+                let children = room.get_children(world);
+                for child in children.clone() {
+                    context.append(child.clone());
+                    // Go over 2nd level children
+                    let children_2 = child.get_children(world);
+                    for child_2 in children_2 {
+                        context.append(child_2.clone());
+                        // Go over 3rd level children
+                        let children_3 = child_2.get_children(world);
+                        for child_3 in children_3 {
+                            context.append(child_3);
                         }
-                    }
+                    };
+                    // // If child inst is equal to the one of the player, go over the children it
+                // has if (*self.inst == child.inst) {
+                //     let children_2 = child.get_children(world);
+                //     for child_2 in children_2 {
+                //         context.append(child_2.clone());
+                //         // If child_2 inst is equal to the one of the player, go over the
+                //         // children it has
+                //         if (*self.inst == child_2.inst) {
+                //             let children_3 = child_2.get_children(world);
+                //             for child_3 in children_3 {
+                //                 context.append(child_3);
+                //             }
+                //         }
+                //     }
+                // }
                 };
                 context
             },

--- a/packages/contracts/src/lib/a_lexer.cairo
+++ b/packages/contracts/src/lib/a_lexer.cairo
@@ -209,7 +209,7 @@ pub mod lexer {
 
     fn match_player_context(world: WorldStorage, player: Player, mut command: Command) -> Command {
         // get player for their context (room + room objects + inventory)
-        let context = player.get_context(@world);
+        let context = player.get_full_context(@world);
         let mut newTokens: Array<Token> = array![];
         for i in 0..command.tokens.len() {
             let mut token = command.tokens.at(i).clone();

--- a/packages/contracts/src/lib/c_handler.cairo
+++ b/packages/contracts/src/lib/c_handler.cairo
@@ -13,7 +13,7 @@ use lore::{ //
     components::{
         player::{Player, PlayerImpl}, area::{AreaComponent}, exit::{Exit, ExitComponent}, Component,
         inspectable::{Inspectable, InspectableImpl, InspectableComponent},
-        inventoryItem::{InventoryItemComponent},
+        inventoryItem::{InventoryItemComponent}, container::{ContainerComponent},
     } //
 };
 
@@ -70,6 +70,17 @@ pub fn handle_command(
                 Option::None => {},
             };
             match InventoryItemComponent::get_component(world, item.inst) {
+                Option::Some(c) => {
+                    if c.can_use_command(world, @player, @command) {
+                        if c.execute_command(world, @player, @command).is_ok() {
+                            executed = true;
+                            break;
+                        }
+                    }
+                },
+                Option::None => {},
+            };
+            match ContainerComponent::get_component(world, item.inst) {
                 Option::Some(c) => {
                     if c.can_use_command(world, @player, @command) {
                         if c.execute_command(world, @player, @command).is_ok() {

--- a/packages/contracts/src/lib/c_handler.cairo
+++ b/packages/contracts/src/lib/c_handler.cairo
@@ -13,6 +13,7 @@ use lore::{ //
     components::{
         player::{Player, PlayerImpl}, area::{AreaComponent}, exit::{Exit, ExitComponent}, Component,
         inspectable::{Inspectable, InspectableImpl, InspectableComponent},
+        inventoryItem::{InventoryItemComponent},
     } //
 };
 
@@ -33,6 +34,7 @@ pub fn handle_command(
     if nouns.len() > 0 {
         for noun in nouns {
             let item = EntityImpl::get_entity(@world, @noun.target).unwrap();
+            player.say(world, format!("item: {:?}", item));
             match InspectableComponent::get_component(world, item.inst) {
                 Option::Some(c) => {
                     if c.clone().can_use_command(world, @player, @command) {
@@ -54,7 +56,7 @@ pub fn handle_command(
                     }
                 },
                 Option::None => {},
-            }
+            };
             // @dev: guaranteed there's a noun
             match ExitComponent::get_component(world, item.inst) {
                 Option::Some(c) => {
@@ -66,7 +68,18 @@ pub fn handle_command(
                     }
                 },
                 Option::None => {},
-            }
+            };
+            match InventoryItemComponent::get_component(world, item.inst) {
+                Option::Some(c) => {
+                    if c.can_use_command(world, @player, @command) {
+                        if c.execute_command(world, @player, @command).is_ok() {
+                            executed = true;
+                            break;
+                        }
+                    }
+                },
+                Option::None => {},
+            };
         };
     } else if directions.len() > 0 {
         let context = player.get_context(@world);

--- a/packages/contracts/src/lib/c_handler.cairo
+++ b/packages/contracts/src/lib/c_handler.cairo
@@ -45,7 +45,7 @@ pub fn handle_command(
                     }
                 },
                 Option::None => {},
-            };
+            }
             match AreaComponent::get_component(world, item.inst) {
                 Option::Some(c) => {
                     if c.can_use_command(world, @player, @command) {
@@ -56,7 +56,7 @@ pub fn handle_command(
                     }
                 },
                 Option::None => {},
-            };
+            }
             // @dev: guaranteed there's a noun
             match ExitComponent::get_component(world, item.inst) {
                 Option::Some(c) => {
@@ -68,7 +68,7 @@ pub fn handle_command(
                     }
                 },
                 Option::None => {},
-            };
+            }
             match InventoryItemComponent::get_component(world, item.inst) {
                 Option::Some(c) => {
                     if c.can_use_command(world, @player, @command) {
@@ -79,7 +79,7 @@ pub fn handle_command(
                     }
                 },
                 Option::None => {},
-            };
+            }
             match ContainerComponent::get_component(world, item.inst) {
                 Option::Some(c) => {
                     if c.can_use_command(world, @player, @command) {

--- a/packages/contracts/src/lib/dictionary.cairo
+++ b/packages/contracts/src/lib/dictionary.cairo
@@ -164,6 +164,9 @@ pub fn init_dictionary(world: WorldStorage) {
     add_to_dictionary(world, "ball", TokenType::Noun, 1).unwrap();
     add_to_dictionary(world, "bag", TokenType::Noun, 1).unwrap();
     add_to_dictionary(world, "chest", TokenType::Noun, 1).unwrap();
+    add_to_dictionary(world, "ring", TokenType::Noun, 1).unwrap();
+    add_to_dictionary(world, "sword", TokenType::Noun, 1).unwrap();
+    add_to_dictionary(world, "player", TokenType::Noun, 1).unwrap();
     // interrogatives
     add_to_dictionary(world, "who", TokenType::Interrogative, 1).unwrap();
     add_to_dictionary(world, "what", TokenType::Interrogative, 2).unwrap();

--- a/packages/contracts/src/lib/dictionary.cairo
+++ b/packages/contracts/src/lib/dictionary.cairo
@@ -70,6 +70,7 @@ pub fn init_dictionary(world: WorldStorage) {
     add_to_dictionary(world, "enter", TokenType::Verb, 1).unwrap();
     add_to_dictionary(world, "climb", TokenType::Verb, 1).unwrap();
     add_to_dictionary(world, "pickup", TokenType::Verb, 1).unwrap();
+    add_to_dictionary(world, "check", TokenType::Verb, 1).unwrap();
 
     // directions
     add_to_dictionary(world, "north", TokenType::Direction, 1).unwrap();
@@ -162,6 +163,7 @@ pub fn init_dictionary(world: WorldStorage) {
     add_to_dictionary(world, "object", TokenType::Noun, 1).unwrap();
     add_to_dictionary(world, "ball", TokenType::Noun, 1).unwrap();
     add_to_dictionary(world, "bag", TokenType::Noun, 1).unwrap();
+    add_to_dictionary(world, "chest", TokenType::Noun, 1).unwrap();
     // interrogatives
     add_to_dictionary(world, "who", TokenType::Interrogative, 1).unwrap();
     add_to_dictionary(world, "what", TokenType::Interrogative, 2).unwrap();

--- a/packages/contracts/src/lib/dictionary.cairo
+++ b/packages/contracts/src/lib/dictionary.cairo
@@ -161,6 +161,7 @@ pub fn init_dictionary(world: WorldStorage) {
     add_to_dictionary(world, "noun", TokenType::Noun, 1).unwrap();
     add_to_dictionary(world, "object", TokenType::Noun, 1).unwrap();
     add_to_dictionary(world, "ball", TokenType::Noun, 1).unwrap();
+    add_to_dictionary(world, "bag", TokenType::Noun, 1).unwrap();
     // interrogatives
     add_to_dictionary(world, "who", TokenType::Interrogative, 1).unwrap();
     add_to_dictionary(world, "what", TokenType::Interrogative, 2).unwrap();

--- a/packages/contracts/src/lib/dictionary.cairo
+++ b/packages/contracts/src/lib/dictionary.cairo
@@ -69,6 +69,7 @@ pub fn init_dictionary(world: WorldStorage) {
     add_to_dictionary(world, "use", TokenType::Verb, 1).unwrap();
     add_to_dictionary(world, "enter", TokenType::Verb, 1).unwrap();
     add_to_dictionary(world, "climb", TokenType::Verb, 1).unwrap();
+    add_to_dictionary(world, "pickup", TokenType::Verb, 1).unwrap();
 
     // directions
     add_to_dictionary(world, "north", TokenType::Direction, 1).unwrap();
@@ -159,6 +160,7 @@ pub fn init_dictionary(world: WorldStorage) {
     // nouns
     add_to_dictionary(world, "noun", TokenType::Noun, 1).unwrap();
     add_to_dictionary(world, "object", TokenType::Noun, 1).unwrap();
+    add_to_dictionary(world, "ball", TokenType::Noun, 1).unwrap();
     // interrogatives
     add_to_dictionary(world, "who", TokenType::Interrogative, 1).unwrap();
     add_to_dictionary(world, "what", TokenType::Interrogative, 2).unwrap();

--- a/packages/contracts/src/systems/designer.cairo
+++ b/packages/contracts/src/systems/designer.cairo
@@ -1,4 +1,6 @@
-use lore::components::{inspectable::{Inspectable}, area::Area, exit::Exit};
+use lore::components::{
+    inspectable::{Inspectable}, area::Area, exit::Exit, inventoryItem::InventoryItem,
+};
 use lore::lib::{entity::Entity, relations::{ParentToChildren, ChildToParent}};
 
 #[starknet::interface]
@@ -7,6 +9,7 @@ pub trait IDesigner<TContractState> {
     fn create_inspectable(ref self: TContractState, t: Array<Inspectable>);
     fn create_area(ref self: TContractState, t: Array<Area>);
     fn create_exit(ref self: TContractState, t: Array<Exit>);
+    fn create_inventory_item(ref self: TContractState, t: Array<InventoryItem>);
     fn create_parent(ref self: TContractState, t: Array<ParentToChildren>);
     fn create_child(ref self: TContractState, t: Array<ChildToParent>);
     //
@@ -14,6 +17,7 @@ pub trait IDesigner<TContractState> {
     fn delete_inspectable(ref self: TContractState, ids: Array<felt252>);
     fn delete_area(ref self: TContractState, ids: Array<felt252>);
     fn delete_exit(ref self: TContractState, ids: Array<felt252>);
+    fn delete_inventory_item(ref self: TContractState, ids: Array<felt252>);
     fn delete_parent(ref self: TContractState, ids: Array<felt252>);
     fn delete_child(ref self: TContractState, ids: Array<felt252>);
 }
@@ -21,7 +25,9 @@ pub trait IDesigner<TContractState> {
 #[dojo::contract]
 pub mod designer {
     use super::IDesigner;
-    use lore::components::{inspectable::{Inspectable}, area::Area, exit::Exit};
+    use lore::components::{
+        inspectable::{Inspectable}, area::Area, exit::Exit, inventoryItem::InventoryItem,
+    };
     use lore::lib::{entity::Entity, relations::{ParentToChildren, ChildToParent}};
     use dojo::{model::ModelStorage};
 
@@ -50,6 +56,13 @@ pub mod designer {
         }
 
         fn create_exit(ref self: ContractState, t: Array<Exit>) {
+            let mut world = self.world(@"lore");
+            for o in t {
+                world.write_model(@o);
+            }
+        }
+
+        fn create_inventory_item(ref self: ContractState, t: Array<InventoryItem>) {
             let mut world = self.world(@"lore");
             for o in t {
                 world.write_model(@o);
@@ -102,6 +115,14 @@ pub mod designer {
             let mut world = self.world(@"lore");
             for inst in ids {
                 let model: Exit = world.read_model(inst);
+                world.erase_model(@model);
+            }
+        }
+
+        fn delete_inventory_item(ref self: ContractState, ids: Array<felt252>) {
+            let mut world = self.world(@"lore");
+            for inst in ids {
+                let model: InventoryItem = world.read_model(inst);
                 world.erase_model(@model);
             }
         }

--- a/packages/contracts/src/systems/designer.cairo
+++ b/packages/contracts/src/systems/designer.cairo
@@ -1,5 +1,6 @@
 use lore::components::{
     inspectable::{Inspectable}, area::Area, exit::Exit, inventoryItem::InventoryItem,
+    container::Container,
 };
 use lore::lib::{entity::Entity, relations::{ParentToChildren, ChildToParent}};
 
@@ -10,6 +11,7 @@ pub trait IDesigner<TContractState> {
     fn create_area(ref self: TContractState, t: Array<Area>);
     fn create_exit(ref self: TContractState, t: Array<Exit>);
     fn create_inventory_item(ref self: TContractState, t: Array<InventoryItem>);
+    fn create_container(ref self: TContractState, t: Array<Container>);
     fn create_parent(ref self: TContractState, t: Array<ParentToChildren>);
     fn create_child(ref self: TContractState, t: Array<ChildToParent>);
     //
@@ -18,6 +20,7 @@ pub trait IDesigner<TContractState> {
     fn delete_area(ref self: TContractState, ids: Array<felt252>);
     fn delete_exit(ref self: TContractState, ids: Array<felt252>);
     fn delete_inventory_item(ref self: TContractState, ids: Array<felt252>);
+    fn delete_container(ref self: TContractState, ids: Array<felt252>);
     fn delete_parent(ref self: TContractState, ids: Array<felt252>);
     fn delete_child(ref self: TContractState, ids: Array<felt252>);
 }
@@ -27,6 +30,7 @@ pub mod designer {
     use super::IDesigner;
     use lore::components::{
         inspectable::{Inspectable}, area::Area, exit::Exit, inventoryItem::InventoryItem,
+        container::Container,
     };
     use lore::lib::{entity::Entity, relations::{ParentToChildren, ChildToParent}};
     use dojo::{model::ModelStorage};
@@ -63,6 +67,13 @@ pub mod designer {
         }
 
         fn create_inventory_item(ref self: ContractState, t: Array<InventoryItem>) {
+            let mut world = self.world(@"lore");
+            for o in t {
+                world.write_model(@o);
+            }
+        }
+
+        fn create_container(ref self: ContractState, t: Array<Container>) {
             let mut world = self.world(@"lore");
             for o in t {
                 world.write_model(@o);
@@ -123,6 +134,14 @@ pub mod designer {
             let mut world = self.world(@"lore");
             for inst in ids {
                 let model: InventoryItem = world.read_model(inst);
+                world.erase_model(@model);
+            }
+        }
+
+        fn delete_container(ref self: ContractState, ids: Array<felt252>) {
+            let mut world = self.world(@"lore");
+            for inst in ids {
+                let model: Container = world.read_model(inst);
                 world.erase_model(@model);
             }
         }


### PR DESCRIPTION
# Description

Implementation of  Inventory items that can be go in and out of containers.
Ex: `pickup the ball` , `drop the ball`, `put the ball in the chest`, `take out the ball from the chest`

## Related issues

Closes #29 

## Introduced changes

Changes on two fronts:
### InventoryItem
Implementation of `InventoryItemComponent`, mapping of actions tokens with the corresponding  container functions.
Implementation of `get_entity_container` for a specific container and `get_player_container` for a specific container entity (Ex: a backpack) that the player has.

### Container
Implementation of `ContainerComponent`, mapping of actions tokens with the corresponding functions: `close container`, `open container`, `check container`. 

Implementation of container's traits such as `contains`, `is_full`,  `can_put_item`, among others.

### Player
Implementation of `get_personal_container` for a container component  if the player has it.

### Designer
Added corresponding functions for adding  and deleting the `InventoryItem` component as well the `Container` component.

### FE
Implementation of the `InventoryItemInspector` and `ContainerInspector` as well adding them as components, and publishing them.

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
