### PR TITLE
feat: Support multi-word dictionary entries in lexer

### DIFF
--- a/packages/contracts/src/lib/a_lexer.cairo
+++ b/packages/contracts/src/lib/a_lexer.cairo
@@ -181,29 +181,61 @@ pub mod lexer {
 
     fn match_tokens(world: WorldStorage, words: Array<ByteArray>) -> Array<Token> {
         let mut tokens: Array<Token> = array![];
-        for i in 0..words.len() {
-            // iterate over the words in the string and find a dictionary match
-            let mut token = Token {
-                position: i,
-                text: words[i].clone(),
-                token_type: TokenType::Unknown,
-                token_value: 0,
-                target: 0,
+        let mut i: u32 = 0;
+
+        while i < words.len() {
+            let mut matched = false;
+            let mut max_match_length = 1;
+            let mut best_match: Option<Token> = Option::None;
+
+            // Try matching sequences of increasing length from current position
+            for len in 1..(words.len() - i + 1) {
+                // Build the sequence of words to try matching
+                let mut sequence = "";
+                for j in 0..len {
+                    if j > 0 {
+                        sequence = sequence + " ";
+                    }
+                    sequence = sequence + words[i + j].clone();
+                };
+                // Try to match this sequence in the dictionary
+                let dict_entry = get_dict_entry(world, sequence.clone());
+                if dict_entry.is_some() {
+                    let dict_entry = dict_entry.unwrap();
+                    max_match_length = len;
+                    best_match =
+                        Option::Some(
+                            Token {
+                                position: i,
+                                text: sequence.clone(),
+                                token_type: dict_entry.tokenType.clone(),
+                                token_value: dict_entry.n_value,
+                                target: 0,
+                            },
+                        );
+                    matched = true;
+                }
             };
-            let dict_entry = get_dict_entry(world, words[i].clone());
-            if dict_entry.is_some() {
-                let dict_entry = dict_entry.unwrap();
-                token =
-                    Token {
-                        position: i,
-                        text: words[i].clone(),
-                        token_type: dict_entry.tokenType.clone(),
-                        token_value: dict_entry.n_value,
-                        target: 0,
-                    };
+            if matched {
+                // Add the best match we found
+                tokens.append(best_match.unwrap());
+                i += max_match_length;
+            } else {
+                // No match found, add as unknown token
+                tokens
+                    .append(
+                        Token {
+                            position: i,
+                            text: words[i].clone(),
+                            token_type: TokenType::Unknown,
+                            token_value: 0,
+                            target: 0,
+                        },
+                    );
+                i += 1;
             }
-            tokens.append(token);
         };
+
         tokens
     }
 

--- a/packages/contracts/src/lib/dictionary.cairo
+++ b/packages/contracts/src/lib/dictionary.cairo
@@ -31,7 +31,11 @@ pub fn add_to_dictionary(
 }
 
 pub fn get_dict_entry(world: WorldStorage, word: ByteArray) -> Option<Dict> {
-    let dict_key: felt252 = word.clone().to_felt252_word().unwrap();
+    let dict_key_result = word.clone().to_felt252_word();
+    if dict_key_result.is_err() {
+        return Option::None;
+    }
+    let dict_key: felt252 = dict_key_result.unwrap();
     let entry: Dict = world.read_model(dict_key);
     if (entry.word == "") {
         return Option::None;


### PR DESCRIPTION
The lexer now matches sequences of words against the dictionary instead of just single words, allowing for phrases and compound terms to be recognized.

# Description

<!--
A description of what this PR is solving.
-->

## Related issues

Closes https://github.com/ArchetypalTech/LORE/issues/34

<!--
Please link related issues: Fixes #<issue_number> or Closes #<issue_number>.
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Introduced changes

<!-- A brief description of the changes -->

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
