### PR TITLE
feat: 83 inspectables description mapped to action map

### DIFF
--- a/packages/client/src/editor/components/EntityEditor.tsx
+++ b/packages/client/src/editor/components/EntityEditor.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useCallback, useEffect } from "react";
 import type { BigNumberish } from "starknet";
 import EditorData, { useEditorData } from "../data/editor.data";
@@ -12,6 +13,17 @@ import { NoEntity } from "./ui/NoEntity";
 
 export const EntityEditor = ({ inst }: { inst: BigNumberish }) => {
 	const { editedEntity, isDirty } = useEditorData();
+
+	 // State to track open/closed status per component key
+  const [openComponents, setOpenComponents] = useState<Record<string, boolean>>({});
+
+  // Toggle function for a single component
+  const toggleComponent = (key: string) => {
+    setOpenComponents((prev) => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  };
 
 	useEffect(() => {
 		if (editedEntity === undefined && inst !== undefined) {
@@ -106,25 +118,48 @@ export const EntityEditor = ({ inst }: { inst: BigNumberish }) => {
 					}}
 				/>
 			</Header>
-			<div className="flex flex-col gap-0 rounded-md shadow-xs">
-				{allComponents().map(({ key, Inspector, componentObject }) => {
-					if (!Inspector) return <div key={key}>{key}</div>;
-					if (componentObject === undefined) return null;
-					return (
-						<Inspector
-							key={key}
-							componentObject={componentObject}
-							componentName={key}
-							handleEdit={handleEditComponent}
-							handleRemove={handleRemoveComponent}
-						/>
-					);
-				})}
-			</div>
-			<AddComponents
-				editedEntity={editedEntity}
-				handleEdit={handleEditComponent}
-			/>
-		</div>
-	);
+			  <div className="flex flex-col gap-0 rounded-md shadow-xs">
+        {allComponents().map(({ key, Inspector, componentObject }) => {
+          if (!Inspector) return <div key={key}>{key}</div>;
+          if (componentObject === undefined) return null;
+
+          const isOpen = openComponents[key as string] ?? true; // default open
+
+          return (
+            <div key={key} className="border-b border-gray-300">
+              {/* Header with toggle button */}
+              <div
+								className="flex items-center justify-between bg-gray-100 px-2 py-1 cursor-pointer select-none"
+								onClick={() => toggleComponent(key as string)}
+								aria-expanded={isOpen}
+								role="button"
+								tabIndex={0}
+								onKeyDown={(e) => {
+									if (e.key === "Tab" || e.key === " ") {
+										e.preventDefault();
+										toggleComponent(key as string);
+									}
+								}}
+							>
+								<span className="font-semibold">{key}</span>
+								<span className="text-xs">{isOpen ? "▼" : "▶"}</span>
+							</div>
+
+              {/* Conditionally render the inspector */}
+              {isOpen && (
+                <Inspector
+                  componentObject={componentObject}
+                  componentName={key}
+                  handleEdit={handleEditComponent}
+                  handleRemove={handleRemoveComponent}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <AddComponents editedEntity={editedEntity} handleEdit={handleEditComponent} />
+    </div>
+  );
 };

--- a/packages/client/src/editor/components/FormComponents.tsx
+++ b/packages/client/src/editor/components/FormComponents.tsx
@@ -282,10 +282,11 @@ export const ActionMapInput = <T extends CairoCustomEnum>({
 	cairoEnum: readonly string[];
 	idx: number;
 }) => {
-	const [input, setInput] = useState(actionMap.action);
+	const [input, setInput] = useState(actionMap.action as string);
 	const [enumValue, setEnumValue] = useState(
 		actionMap.action_fn as CairoCustomEnum,
 	);
+	const [entrypoint, setEntrypoint] = useState(actionMap.entrypoint as BigNumberish);
 
 	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const newValue = e.target.value;
@@ -303,6 +304,7 @@ export const ActionMapInput = <T extends CairoCustomEnum>({
 				action: action.action.trim(),
 				inst: action.inst,
 				action_fn: action.action_fn,
+				entrypoint: action.entrypoint,
 			},
 			idx,
 		);
@@ -315,6 +317,16 @@ export const ActionMapInput = <T extends CairoCustomEnum>({
 			action_fn: newValue,
 		} as ActionMap<T>;
 		setEnumValue(newValue);
+		return newActionMap;
+	};
+
+	const handleEntrypointChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const newValue = e.target.value;
+		const newActionMap = {
+			...actionMap,
+			entrypoint: newValue,
+		} as ActionMap<T>;
+		setEntrypoint(newValue);
 		return newActionMap;
 	};
 
@@ -339,8 +351,17 @@ export const ActionMapInput = <T extends CairoCustomEnum>({
 						submit(a);
 					}}
 					enum={cairoEnum}
-					className="bg-white rounded-md flex grow"
+					className="bg-white rounded-md flex-[0.3] min-w-[12rem]"
 					hideLabel={true}
+				/>
+				<UIInput
+					id={actionMap.entrypoint}
+					value={entrypoint}
+					onChange={(e) => {
+						let a = handleEntrypointChange(e);
+						submit(a);
+					}}
+					className="bg-white col-span-1 border-solid flex-1"
 				/>
 			</div>
 				<DeleteButton
@@ -409,6 +430,7 @@ export const ActionMapEditor = <T extends CairoCustomEnum>({
 			action: "",
 			inst: 0,
 			action_fn: cairoEnum[0],
+			entrypoint: 0,
 		});
 		sendEvent(newActionMap);
 	};

--- a/packages/client/src/editor/components/MultiTextArea.tsx
+++ b/packages/client/src/editor/components/MultiTextArea.tsx
@@ -100,6 +100,9 @@ export const MultiTextArea = ({
 						</div>
 					);
 				})}
+				<Button variant="secondary" onClick={handleAddArray}>
+					Add {id}
+				</Button>
 			</div>
 		</>
 	);

--- a/packages/client/src/editor/lib/components.ts
+++ b/packages/client/src/editor/lib/components.ts
@@ -94,8 +94,8 @@ export const createDefaultInspectableComponent = (
 		is_visible: true,
 		description: [entity.name],
 		action_map: [
-			{ action: "look", inst: 0, action_fn: "ReadRandomDescription" },
-			{ action: "stare", inst: 0, action_fn: "ReadRandomDescription" },
+			{ action: "look", inst: 0, action_fn: "ReadRandomDescription", entrypoint: 1 },
+			{ action: "stare", inst: 0, action_fn: "ReadRandomDescription", entrypoint: 1 },
 		],
 	},
 });

--- a/packages/client/src/editor/lib/types.ts
+++ b/packages/client/src/editor/lib/types.ts
@@ -95,6 +95,7 @@ export interface ActionMap<T> {
 	action: string;
 	inst: BigNumberish;
 	action_fn: T;
+	entrypoint: BigNumberish;
 }
 
 export interface TriggerParameter {

--- a/packages/client/src/editor/publisher.ts
+++ b/packages/client/src/editor/publisher.ts
@@ -172,6 +172,7 @@ const publishInspectable = async (inspectable: Inspectable) => {
 					byteArray.byteArrayFromString(x.action),
 					0,
 					toEnumIndex(x.action_fn, inspectableActions),
+					num.toBigInt(x.entrypoint.toString()),
 				])
 			: 0,
 	];

--- a/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
@@ -72,6 +72,7 @@ export interface ActionMapInspectable {
 	action: string;
 	inst: BigNumberish;
 	action_fn: InspectableActionsEnum;
+	entrypoint: BigNumberish;
 }
 
 // Type definition for `lore::components::inspectable::Inspectable` struct
@@ -402,6 +403,7 @@ export const inspectableActions = [
 	'SetVisible',
 	'ReadRandomDescription',
 	'ReadFirstDescription',
+	'ReadSpecificDescription',
 ] as const;
 export type InspectableActions = { [key in typeof inspectableActions[number]]: string };
 export type InspectableActionsEnum = CairoCustomEnum;
@@ -628,7 +630,9 @@ export const schema: SchemaType = {
 		action_fn: new CairoCustomEnum({ 
 					SetVisible: "",
 				ReadRandomDescription: undefined,
-				ReadFirstDescription: undefined, }),
+				ReadFirstDescription: undefined,
+				ReadSpecificDescription: undefined, }),
+			entrypoint: 0,
 		},
 		Inspectable: {
 			inst: 0,
@@ -638,7 +642,8 @@ export const schema: SchemaType = {
 			action_map: [{ action: "", inst: 0, action_fn: new CairoCustomEnum({ 
 					SetVisible: "",
 				ReadRandomDescription: undefined,
-				ReadFirstDescription: undefined, }), }],
+				ReadFirstDescription: undefined,
+				ReadSpecificDescription: undefined, }), entrypoint: 0, }],
 		},
 		InspectableValue: {
 			is_inspectable: false,
@@ -647,7 +652,8 @@ export const schema: SchemaType = {
 			action_map: [{ action: "", inst: 0, action_fn: new CairoCustomEnum({ 
 					SetVisible: "",
 				ReadRandomDescription: undefined,
-				ReadFirstDescription: undefined, }), }],
+				ReadFirstDescription: undefined,
+				ReadSpecificDescription: undefined, }), entrypoint: 0, }],
 		},
 		ActionMapInventoryItem: {
 		action: "",

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -1328,8 +1328,8 @@
   },
   "contracts": [
     {
-      "address": "0x7358057a1606c52a5005891140a24c3d49fe6bb5dcb844aaae03ddfe206f913",
-      "class_hash": "0x20ffb36082f470c8fa4d19d80ae280bd85e7d4c5ab35c9d54d815e5d458cfd4",
+      "address": "0x63e9c45621cc56faa4c479bf41687d205b8c85c0e1c5d622e8a39cb865023f2",
+      "class_hash": "0x145022b8349f3c7402eb70dee6603edb396d52f4e59edea4dfabfcdc3c029fb",
       "abi": [
         {
           "type": "impl",
@@ -1467,6 +1467,10 @@
             {
               "name": "ReadFirstDescription",
               "type": "()"
+            },
+            {
+              "name": "ReadSpecificDescription",
+              "type": "()"
             }
           ]
         },
@@ -1485,6 +1489,10 @@
             {
               "name": "action_fn",
               "type": "lore::components::inspectable::InspectableActions"
+            },
+            {
+              "name": "entrypoint",
+              "type": "core::integer::u32"
             }
           ]
         },
@@ -2499,8 +2507,8 @@
       ]
     },
     {
-      "address": "0x164ee225762e8a7dfcc6f2873883ece2a1c365ef3ad4b567ffef55d478f6dde",
-      "class_hash": "0x1f5dbb2c1d841552e1b2664698e459af95401ca172a5bf235899905cf6e1ee3",
+      "address": "0x4f4faad4c59194993bd6ba27358f973015daca7db503dd4ead710215eaa5bad",
+      "class_hash": "0x64772911a701b8808d62b748795e944f4f6bc2210634676fa4bfe0b46096062",
       "abi": [
         {
           "type": "impl",
@@ -2769,7 +2777,7 @@
     },
     {
       "members": [],
-      "class_hash": "0x716e3efb30fdfbb7ba1e9203eca6cb5411e1618b707f4f465f0a2a2168fadc3",
+      "class_hash": "0x534e52be1607c679c80ed54c93220fbd334a6dc227edd212406be21131621e0",
       "tag": "lore-Inspectable",
       "selector": "0x761c792e623173857f21316868bd06f19050cfc26238d33476231e335cf59c9"
     },

--- a/packages/contracts/src/components/inspectable.cairo
+++ b/packages/contracts/src/components/inspectable.cairo
@@ -12,6 +12,7 @@ pub enum InspectableActions {
     SetVisible,
     ReadRandomDescription,
     ReadFirstDescription,
+    ReadSpecificDescription,
 }
 
 #[derive(Clone, Drop, Serde, Debug)]
@@ -31,6 +32,7 @@ pub struct ActionMapInspectable {
     pub action: ByteArray,
     pub inst: felt252,
     pub action_fn: InspectableActions,
+    pub entrypoint: u32,
 }
 
 #[generate_trait]
@@ -55,6 +57,14 @@ pub impl InspectableImpl of InspectableTrait {
             return "";
         }
         let description = self.description.at(0).clone();
+        description
+    }
+
+    fn get_specific_description(inspectabe: @Inspectable, index: u32) -> ByteArray {
+        if inspectabe.description.len() == 0 {
+            return "";
+        }
+        let description = inspectabe.description.at(index).clone();
         description
     }
 }
@@ -87,11 +97,19 @@ pub impl InspectableComponent of Component<Inspectable> {
                         action: "look",
                         inst: 0,
                         action_fn: InspectableActions::ReadRandomDescription,
+                        entrypoint: 0,
                     },
                     ActionMapInspectable {
                         action: "stare",
                         inst: 0,
-                        action_fn: InspectableActions::ReadRandomDescription,
+                        action_fn: InspectableActions::ReadFirstDescription,
+                        entrypoint: 1,
+                    },
+                    ActionMapInspectable {
+                        action: "read",
+                        inst: 0,
+                        action_fn: InspectableActions::ReadSpecificDescription,
+                        entrypoint: 2,
                     },
                 ];
         inspectable.store(world);
@@ -132,6 +150,13 @@ pub impl InspectableComponent of Component<Inspectable> {
                 player.say(world, self.get_first_description(world));
                 return Result::Ok(());
             },
+            InspectableActions::ReadSpecificDescription => {
+                // Get idx from the action map entrypoint
+                let idx: u32 = action.entrypoint.try_into().unwrap();
+                // Say the description
+                player.say(world, InspectableImpl::get_specific_description(@self, idx));
+                return Result::Ok(());
+            },
         }
         Result::Err(Error::ActionFailed)
     }
@@ -164,6 +189,7 @@ mod tests {
     use dojo::{world::WorldStorage, model::ModelStorage};
     use super::*;
     use lore::tests::helpers;
+    use lore::components::inspectable::InspectableImpl;
 
     fn Inspectable_create_prefab() -> (
         Inspectable, WorldStorage, ContractAddress, ContractAddress,
@@ -179,13 +205,26 @@ mod tests {
                 "how big is a rock",
                 "what's up with the rock",
                 "let's talk about the rock",
+                "the rock is from the moon",
             ],
             action_map: array![
                 ActionMapInspectable {
-                    action: "show", inst: 0, action_fn: InspectableActions::SetVisible,
+                    action: "show",
+                    inst: 0,
+                    action_fn: InspectableActions::SetVisible,
+                    entrypoint: 0,
                 },
                 ActionMapInspectable {
-                    action: "look", inst: 0, action_fn: InspectableActions::ReadRandomDescription,
+                    action: "look",
+                    inst: 0,
+                    action_fn: InspectableActions::ReadRandomDescription,
+                    entrypoint: 1,
+                },
+                ActionMapInspectable {
+                    action: "read",
+                    inst: 0,
+                    action_fn: InspectableActions::ReadSpecificDescription,
+                    entrypoint: 5,
                 },
             ],
         };
@@ -211,5 +250,14 @@ mod tests {
         let (prefab, world, _, _) = Inspectable_create_prefab();
         let i: Inspectable = Component::get_component(world, prefab.inst).unwrap();
         assert(i.is_inspectable, 'inspectable is inspectable');
+    }
+
+    #[test]
+    fn Inspectable_test_read_specific_description() {
+        let (prefab, world, _, _) = Inspectable_create_prefab();
+        let i: Inspectable = Component::get_component(world, prefab.inst).unwrap();
+        let idx: u32 = 5;
+        let res = InspectableImpl::get_specific_description(@i, idx);
+        assert(res == "the rock is from the moon", 'description should be the moon');
     }
 }

--- a/packages/contracts/src/lib/actions.cairo
+++ b/packages/contracts/src/lib/actions.cairo
@@ -220,12 +220,16 @@ mod tests {
             .action_map =
                 array![
                     ActionMapInspectable {
-                        action: "show", inst: 0, action_fn: InspectableActions::SetVisible,
+                        action: "show",
+                        inst: 0,
+                        action_fn: InspectableActions::SetVisible,
+                        entrypoint: 0,
                     },
                     ActionMapInspectable {
                         action: "look",
                         inst: 0,
                         action_fn: InspectableActions::ReadRandomDescription,
+                        entrypoint: 1,
                     },
                 ];
         inspectable.store(world);
@@ -263,12 +267,16 @@ mod tests {
             .action_map =
                 array![
                     ActionMapInspectable {
-                        action: "show", inst: 0, action_fn: InspectableActions::SetVisible,
+                        action: "show",
+                        inst: 0,
+                        action_fn: InspectableActions::SetVisible,
+                        entrypoint: 0,
                     },
                     ActionMapInspectable {
                         action: "look",
                         inst: 0,
                         action_fn: InspectableActions::ReadRandomDescription,
+                        entrypoint: 1,
                     },
                 ];
         inspectable.store(world);

--- a/packages/contracts/src/lib/condition.cairo
+++ b/packages/contracts/src/lib/condition.cairo
@@ -183,12 +183,16 @@ mod tests {
             .action_map =
                 array![
                     ActionMapInspectable {
-                        action: "show", inst: 0, action_fn: InspectableActions::SetVisible,
+                        action: "show",
+                        inst: 0,
+                        action_fn: InspectableActions::SetVisible,
+                        entrypoint: 0,
                     },
                     ActionMapInspectable {
                         action: "look",
                         inst: 0,
                         action_fn: InspectableActions::ReadRandomDescription,
+                        entrypoint: 1,
                     },
                 ];
         inspectable.store(world);

--- a/packages/contracts/src/lib/dictionary.cairo
+++ b/packages/contracts/src/lib/dictionary.cairo
@@ -71,6 +71,10 @@ pub fn init_dictionary(world: WorldStorage) {
     add_to_dictionary(world, "climb", TokenType::Verb, 1).unwrap();
     add_to_dictionary(world, "pickup", TokenType::Verb, 1).unwrap();
     add_to_dictionary(world, "check", TokenType::Verb, 1).unwrap();
+    add_to_dictionary(world, "examine", TokenType::Verb, 1).unwrap();
+    add_to_dictionary(world, "read", TokenType::Verb, 1).unwrap();
+    add_to_dictionary(world, "touch", TokenType::Verb, 1).unwrap();
+    add_to_dictionary(world, "listen", TokenType::Verb, 1).unwrap();
 
     // directions
     add_to_dictionary(world, "north", TokenType::Direction, 1).unwrap();

--- a/packages/contracts/src/lib/effect.cairo
+++ b/packages/contracts/src/lib/effect.cairo
@@ -326,12 +326,16 @@ mod tests {
             .action_map =
                 array![
                     ActionMapInspectable {
-                        action: "show", inst: 0, action_fn: InspectableActions::SetVisible,
+                        action: "show",
+                        inst: 0,
+                        action_fn: InspectableActions::SetVisible,
+                        entrypoint: 0,
                     },
                     ActionMapInspectable {
                         action: "look",
                         inst: 0,
                         action_fn: InspectableActions::ReadRandomDescription,
+                        entrypoint: 1,
                     },
                 ];
         inspectable.store(world);


### PR DESCRIPTION
# Description

Implementation of mapping description with action using index

## Related issues

Closes #83 

## Introduced changes

Added in the `inspectable.cairo` file a new variable in the `ActionMapInspectable` called `entrypoint`. This variable will map the verb/action to an specific description in the array when the verb/action is of type `ReadSpecificDescription`

Bonus: added a `collapse` and `expand` button to the components in the editor.

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
