### PR TITLE
fix:  temporal solution for data length error in `PlayerStory.story`

### DIFF
--- a/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
@@ -1,6 +1,6 @@
 import type { SchemaType as ISchemaType } from "@dojoengine/sdk";
 
-import { CairoCustomEnum, BigNumberish } from 'starknet';
+import { CairoCustomEnum, type BigNumberish } from 'starknet';
 
 // Type definition for `lore::components::area::Area` struct
 export interface Area {

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -2548,8 +2548,8 @@
       ]
     },
     {
-      "address": "0x277f7d98473fbd898794377ad6c5b2ccd48d79b2a4e49c385592fc3dd9745b",
-      "class_hash": "0x11e124e2db24040ad75809fff9d09ece207c66f37e4b1db27baffd15ccc20b",
+      "address": "0xcdfecd2e8b12d8c97ab8c0be2816fe8d5831fac5bfcf63ca8a2d2a9e8cf4b3",
+      "class_hash": "0x21f442f22fa11165645a89106de80c2c1999dd317462201ca74e1e606748b73",
       "abi": [
         {
           "type": "impl",

--- a/packages/contracts/manifest_slot.json
+++ b/packages/contracts/manifest_slot.json
@@ -2548,8 +2548,8 @@
       ]
     },
     {
-      "address": "0x1becccbcc2f5a55a71a2ca70a1dc2f23a689addb822fdd44ab43e07b8e9f4be",
-      "class_hash": "0x11e124e2db24040ad75809fff9d09ece207c66f37e4b1db27baffd15ccc20b",
+      "address": "0x1c9cc72972b876f6da9cd7221be6825de9f2403ff25cbc1f0e697d12d22bdfb",
+      "class_hash": "0x21f442f22fa11165645a89106de80c2c1999dd317462201ca74e1e606748b73",
       "abi": [
         {
           "type": "impl",

--- a/packages/contracts/src/components/player.cairo
+++ b/packages/contracts/src/components/player.cairo
@@ -76,11 +76,46 @@ pub impl PlayerImpl of PlayerTrait {
     }
 
     fn say(mut self: @Player, mut world: WorldStorage, text: ByteArray) {
-        let mut playerStory: PlayerStory = world.read_model(*self.inst);
-        let mut storyLine = playerStory.story.clone();
-        storyLine.append(text);
-        world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });
+        // let mut playerStory: PlayerStory = world.read_model(*self.inst);
+        // let mut storyLine = playerStory.story.clone();
+        // if (storyLine.len() > 20) {
+        //     let _ = storyLine.pop_front();
+        // }
+        // storyLine.append(text);
+        // world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });
+        const MAX_LENGTH_LIMIT: usize = 2000;
+        let new_text_len = text.len();
+        let mut total_len = 0;
+
+        loop {
+            let playerStoryLoop: PlayerStory = world.read_model(*self.inst);
+            let mut storyLine = playerStoryLoop.story.clone();
+
+            total_len = 0;
+            for line in storyLine.clone() {
+                total_len += line.len();
+            };
+            println!("total_len: {:?}", total_len);
+            println!("new_text_len: {:?}", new_text_len);
+
+            if total_len + new_text_len <= MAX_LENGTH_LIMIT {
+                storyLine.append(text);
+                world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });
+                break;
+            }
+
+            if storyLine.len() == 0 {
+                // Edge case: nothing left to remove, but still too large
+                break;
+            }
+
+            let removed = storyLine.pop_front();
+            total_len -= removed.unwrap().len();
+            println!("total_len after pop: {:?}", total_len);
+            world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });
+        }
     }
+
 
     fn add_command_text(mut self: @Player, mut world: WorldStorage, text: ByteArray) {
         let mut playerStory: PlayerStory = world.read_model(*self.inst);

--- a/packages/contracts/src/components/player.cairo
+++ b/packages/contracts/src/components/player.cairo
@@ -90,7 +90,7 @@ pub impl PlayerImpl of PlayerTrait {
                 total_len += line.len();
             };
 
-            if self.use_debug {
+            if *self.use_debug {
                 self.clone().say(world, format!("Total length: {:?}", total_len));
                 self.clone().say(world, format!("New text length: {:?}", new_text_len));
             }
@@ -108,8 +108,8 @@ pub impl PlayerImpl of PlayerTrait {
 
             let removed = storyLine.pop_front();
             total_len -= removed.unwrap().len();
-            if self.use_debug {
-                println!("total_len after pop: {:?}", total_len);
+            if *self.use_debug {
+                self.clone().say(world, format!("Total length after pop: {:?}", total_len));
             }
 
             world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });

--- a/packages/contracts/src/components/player.cairo
+++ b/packages/contracts/src/components/player.cairo
@@ -75,14 +75,8 @@ pub impl PlayerImpl of PlayerTrait {
         }
     }
 
+    // TODO: improve name and better description
     fn say(mut self: @Player, mut world: WorldStorage, text: ByteArray) {
-        // let mut playerStory: PlayerStory = world.read_model(*self.inst);
-        // let mut storyLine = playerStory.story.clone();
-        // if (storyLine.len() > 20) {
-        //     let _ = storyLine.pop_front();
-        // }
-        // storyLine.append(text);
-        // world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });
         const MAX_LENGTH_LIMIT: usize = 2000;
         let new_text_len = text.len();
         let mut total_len = 0;
@@ -95,8 +89,11 @@ pub impl PlayerImpl of PlayerTrait {
             for line in storyLine.clone() {
                 total_len += line.len();
             };
-            println!("total_len: {:?}", total_len);
-            println!("new_text_len: {:?}", new_text_len);
+
+            if self.use_debug {
+                self.clone().say(world, format!("Total length: {:?}", total_len));
+                self.clone().say(world, format!("New text length: {:?}", new_text_len));
+            }
 
             if total_len + new_text_len <= MAX_LENGTH_LIMIT {
                 storyLine.append(text);
@@ -111,7 +108,10 @@ pub impl PlayerImpl of PlayerTrait {
 
             let removed = storyLine.pop_front();
             total_len -= removed.unwrap().len();
-            println!("total_len after pop: {:?}", total_len);
+            if self.use_debug {
+                println!("total_len after pop: {:?}", total_len);
+            }
+
             world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });
         }
     }


### PR DESCRIPTION
# Description

Temporal fix for the data length error inside the `PlayerStory.story`

## Related issues

Closes #51 


## Introduced changes

Inside the `say` method in `player.cairo` there is now an iteration if the new text length plus the stored text length is less or equal to an specified value it will append the new text. Otherwise, it will be `pop_front` the front element until the new text enters.

## Checklist

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
