### PR TITLE
feat: Improve the setup of triggers, conditions and effects in the Action Component

### DIFF
--- a/packages/client/src/data/command.data.ts
+++ b/packages/client/src/data/command.data.ts
@@ -157,6 +157,17 @@ export const TERMINAL_SYSTEM_COMMANDS: {
 		// Call the check for player
 		await checkForPlayer();
 	},
+	wallet: async () => {
+		if(!WalletStore().isConnected) {
+			addTerminalContent({
+				text: "not connected, connect first",
+				format: "hash",
+				useTypewriter: true,
+			});
+			return;
+		}
+		await WalletStore().openUserProfile();
+	},
 	disconnect: async () => {
 		if (!WalletStore().isConnected) {
 			addTerminalContent({

--- a/packages/client/src/editor/components/ConditionSelector.tsx
+++ b/packages/client/src/editor/components/ConditionSelector.tsx
@@ -4,7 +4,7 @@ import { DeleteButton, Select } from "./FormComponents";
 import { BigNumberish } from "starknet";
 import { formatKeyAsDecimal } from "./FormComponents";
 
-interface TriggerSelectorProps {
+interface ConditionSelectorProps {
   id: string;
   value: Array<[string, BigNumberish]>;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
@@ -12,13 +12,13 @@ interface TriggerSelectorProps {
   readOnly?: boolean;
 }
 
-export const TriggerSelector = ({
+export const ConditionSelector = ({
   id,
   value,
   onChange,
   dataPool,
   readOnly,
-}: TriggerSelectorProps) => {
+}: ConditionSelectorProps) => {
   const handleUpdate = (updated: Array<[string, BigNumberish]>) => {
     const syntheticEvent = {
       target: {
@@ -49,30 +49,30 @@ export const TriggerSelector = ({
 
   const entityOptions = useMemo(() => {
     return Array.from(dataPool.entries())
-      .filter(([_, val]) => val.Entity?.name && val.Trigger?.key)
+      .filter(([_, val]) => val.Entity?.name && val.Condition?.key)
       .map(([address, val]) => ({
         label: val.Entity.name,
         value: address,
       }));
   }, [dataPool]);
 
-  const getTriggerOptions = (entityId: string) => {
+  const getConditionOptions = (entityId: string) => {
     const entity = dataPool.get(entityId);
-    if (!entity || !entity.Trigger) return [];
+    if (!entity || !entity.Condition) return [];
     return [
       {
-        label: formatKeyAsDecimal(entity.Trigger.key),
-        value: entity.Trigger.key.toString(),
+        label: formatKeyAsDecimal(entity.Condition.key),
+        value: entity.Condition.key.toString(),
       },
     ];
   };
 
   return (
     <div className="flex flex-col gap-2">
-      {value.map(([entityId, triggerKey], i) => (
+      {value.map(([entityId, conditionKey], i) => (
         <div key={i} className="flex gap-2 items-center relative">
           <Select
-            id={`trigger-entity-${i}`}
+            id={`condition-entity-${i}`}
             value={entityId}
             onChange={(e) => handleChange(i, 0, e.target.value)}
             disabled={readOnly}
@@ -86,13 +86,13 @@ export const TriggerSelector = ({
           />
 
           <Select
-            id={`trigger-key-${i}`}
-            value={triggerKey?.toString() ?? ""}
+            id={`condition-key-${i}`}
+            value={conditionKey?.toString() ?? ""}
             onChange={(e) => handleChange(i, 1, e.target.value)}
             disabled={readOnly || !entityId}
             options={[
-              { value: "__placeholder__", label: "Select trigger" },
-              ...getTriggerOptions(entityId),
+              { value: "__placeholder__", label: "Select condition" },
+              ...getConditionOptions(entityId),
             ]}
           />
 

--- a/packages/client/src/editor/components/EffectsSelector.tsx
+++ b/packages/client/src/editor/components/EffectsSelector.tsx
@@ -1,0 +1,110 @@
+import { ChangeEvent, useMemo } from "react";
+import { Button } from "./ui/Button";
+import { DeleteButton, Select } from "./FormComponents";
+import { BigNumberish } from "starknet";
+import { formatKeyAsDecimal } from "./FormComponents";
+
+interface EffectSelectorProps {
+  id: string;
+  value: Array<[string, BigNumberish]>;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  dataPool: Map<BigNumberish, any>; // adjust type as needed
+  readOnly?: boolean;
+}
+
+export const EffectSelector = ({
+  id,
+  value,
+  onChange,
+  dataPool,
+  readOnly,
+}: EffectSelectorProps) => {
+  const handleUpdate = (updated: Array<[string, BigNumberish]>) => {
+    const syntheticEvent = {
+      target: {
+        id,
+        name: id,
+        value: updated,
+        type: "array",
+      },
+    } as unknown as ChangeEvent<HTMLInputElement>;
+    onChange(syntheticEvent);
+  };
+
+  const handleChange = (i: number, j: 0 | 1, val: string) => {
+    const updated = [...value];
+    updated[i][j] = val;
+    handleUpdate(updated);
+  };
+
+  const addRow = () => {
+    handleUpdate([...value, ["", ""]]);
+  };
+
+  const removeRow = (i: number) => {
+    const updated = [...value];
+    updated.splice(i, 1);
+    handleUpdate(updated);
+  };
+
+  const entityOptions = useMemo(() => {
+    return Array.from(dataPool.entries())
+      .filter(([_, val]) => val.Entity?.name && val.Effect?.key)
+      .map(([address, val]) => ({
+        label: val.Entity.name,
+        value: address,
+      }));
+  }, [dataPool]);
+
+  const getEffectOptions = (entityId: string) => {
+    const entity = dataPool.get(entityId);
+    if (!entity || !entity.Effect) return [];
+    return [
+      {
+        label: formatKeyAsDecimal(entity.Effect.key),
+        value: entity.Effect.key.toString(),
+      },
+    ];
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {value.map(([entityId, effectKey], i) => (
+        <div key={i} className="flex gap-2 items-center relative">
+          <Select
+            id={`effect-entity-${i}`}
+            value={entityId}
+            onChange={(e) => handleChange(i, 0, e.target.value)}
+            disabled={readOnly}
+            options={[
+            { value: "__placeholder__", label: "Select entity"},
+            ...entityOptions.map((opt) => ({
+              value: opt.value.toString(),
+              label: String(opt.label),
+            })),
+          ]}
+          />
+
+          <Select
+            id={`effect-key-${i}`}
+            value={effectKey?.toString() ?? ""}
+            onChange={(e) => handleChange(i, 1, e.target.value)}
+            disabled={readOnly || !entityId}
+            options={[
+              { value: "__placeholder__", label: "Select effect" },
+              ...getEffectOptions(entityId),
+            ]}
+          />
+
+          <div className="absolute right-0 top-0 scale-50 opacity-50 hover:opacity-100">
+            <DeleteButton onClick={() => removeRow(i)} />
+          </div>
+        </div>
+      ))}
+
+      <Button variant="secondary" onClick={addRow}>
+        Add {id}
+      </Button>
+    </div>
+  );
+}

--- a/packages/client/src/editor/components/TriggerSelector.tsx
+++ b/packages/client/src/editor/components/TriggerSelector.tsx
@@ -1,0 +1,110 @@
+import { ChangeEvent, useMemo } from "react";
+import { Button } from "./ui/Button";
+import { DeleteButton, Select } from "./FormComponents";
+import { BigNumberish } from "starknet";
+import { formatKeyAsDecimal } from "./FormComponents";
+
+interface TriggerSelectorProps {
+  id: string;
+  value: Array<[string, string]>;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  dataPool: Map<BigNumberish, any>; // adjust type as needed
+  readOnly?: boolean;
+}
+
+export const TriggerSelector = ({
+  id,
+  value,
+  onChange,
+  dataPool,
+  readOnly,
+}: TriggerSelectorProps) => {
+  const handleUpdate = (updated: Array<[string, string]>) => {
+    const syntheticEvent = {
+      target: {
+        id,
+        name: id,
+        value: updated,
+        type: "array",
+      },
+    } as unknown as ChangeEvent<HTMLInputElement>;
+    onChange(syntheticEvent);
+  };
+
+  const handleChange = (i: number, j: 0 | 1, val: string) => {
+    const updated = [...value];
+    updated[i][j] = val;
+    handleUpdate(updated);
+  };
+
+  const addRow = () => {
+    handleUpdate([...value, ["", ""]]);
+  };
+
+  const removeRow = (i: number) => {
+    const updated = [...value];
+    updated.splice(i, 1);
+    handleUpdate(updated);
+  };
+
+  const entityOptions = useMemo(() => {
+    return Array.from(dataPool.entries())
+      .filter(([_, val]) => val.Entity?.name && val.Trigger?.key)
+      .map(([address, val]) => ({
+        label: val.Entity.name,
+        value: address,
+      }));
+  }, [dataPool]);
+
+  const getTriggerOptions = (entityId: string) => {
+    const entity = dataPool.get(entityId);
+    if (!entity || !entity.Trigger) return [];
+    return [
+      {
+        label: formatKeyAsDecimal(entity.Trigger.key),
+        value: entity.Trigger.key.toString(),
+      },
+    ];
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {value.map(([entityId, triggerKey], i) => (
+        <div key={i} className="flex gap-2 items-center relative">
+          <Select
+            id={`trigger-entity-${i}`}
+            value={entityId}
+            onChange={(e) => handleChange(i, 0, e.target.value)}
+            disabled={readOnly}
+            options={[
+            { value: "__placeholder__", label: "Select entity"},
+            ...entityOptions.map((opt) => ({
+              value: opt.value.toString(),
+              label: String(opt.label),
+            })),
+          ]}
+          />
+
+          <Select
+            id={`trigger-key-${i}`}
+            value={triggerKey?.toString() ?? ""}
+            onChange={(e) => handleChange(i, 1, e.target.value)}
+            disabled={readOnly || !entityId}
+            options={[
+              { value: "__placeholder__", label: "Select trigger" },
+              ...getTriggerOptions(entityId),
+            ]}
+          />
+
+          <div className="absolute right-0 top-0 scale-50 opacity-50 hover:opacity-100">
+            <DeleteButton onClick={() => removeRow(i)} />
+          </div>
+        </div>
+      ))}
+
+      <Button variant="secondary" onClick={addRow}>
+        Add {id}
+      </Button>
+    </div>
+  );
+}

--- a/packages/client/src/editor/components/inspectors/ActionInspector.tsx
+++ b/packages/client/src/editor/components/inspectors/ActionInspector.tsx
@@ -12,7 +12,9 @@ import {
 import type { ComponentInspector } from "./useInspector";
 import { useInspector } from "./useInspector";
 import { MultiNumberArray } from "../MultiNumberArray";
-import { BigNumberish, num } from "starknet";
+import { TriggerSelector } from "../TriggerSelector";
+import { BigNumberish } from "starknet";
+import { useEditorData } from "../../data/editor.data";
 
 export const ActionInspector: ComponentInspector<Action> = ({
   componentObject,
@@ -32,10 +34,12 @@ export const ActionInspector: ComponentInspector<Action> = ({
         const event = e as ChangeEvent<HTMLInputElement>;
         updatedObject.is_enabled = event.target.checked;
       },
-      trigger: (e, updatedObject) => {
-        const val = e.target.value as unknown as Array<[string, string]>;
-        updatedObject.trigger = val.map(
-          ([a, b]) => [(a), num.toBigInt(b)]
+      triggers: (e, updatedObject) => {
+        const val = e.target.value as unknown as Array<[string, BigNumberish]>;
+        updatedObject.trigger = val
+        .filter(([a, b]) => a !== "__placeholder__" && b !== "__placeholder__")
+        .map(
+          ([a, b]) => [(a), (b)]
         ) as [BigNumberish, BigNumberish][];
       },
       conditions: (e, updatedObject) => {
@@ -101,10 +105,11 @@ export const ActionInspector: ComponentInspector<Action> = ({
         value={componentObject.is_enabled}
         onChange={handleInputChange}
       />
-      <MultiNumberArray
-        id="trigger"
-        value={componentObject.trigger.map(([a, b]) => [formatKeyAsDecimal(a), formatKeyAsDecimal(b)])}
+      <TriggerSelector
+        id="triggers"
+        value={componentObject.trigger.map(([a, b]) => [a.toString(), b])}
         onChange={handleInputChange}
+        dataPool={useEditorData().dataPool}
       />
       <MultiNumberArray
         id="conditions"

--- a/packages/client/src/editor/components/inspectors/ActionInspector.tsx
+++ b/packages/client/src/editor/components/inspectors/ActionInspector.tsx
@@ -11,9 +11,9 @@ import {
 } from "../FormComponents";
 import type { ComponentInspector } from "./useInspector";
 import { useInspector } from "./useInspector";
-import { MultiNumberArray } from "../MultiNumberArray";
 import { TriggerSelector } from "../TriggerSelector";
 import { ConditionSelector } from "../ConditionSelector";
+import { EffectSelector } from "../EffectsSelector";
 import { BigNumberish } from "starknet";
 import { useEditorData } from "../../data/editor.data";
 
@@ -52,8 +52,10 @@ export const ActionInspector: ComponentInspector<Action> = ({
         ) as [BigNumberish, BigNumberish][];
       },
       effects: (e, updatedObject) => {
-        const val = e.target.value as unknown as Array<[string, string]>;
-        updatedObject.effects = val.map(
+        const val = e.target.value as unknown as Array<[string, BigNumberish]>;
+        updatedObject.effects = val
+        .filter(([a, b]) => a !== "__placeholder__" && b !== "__placeholder__")
+        .map(
           ([a, b]) => [(a), (b)]
         ) as [BigNumberish, BigNumberish][];
       },
@@ -120,10 +122,11 @@ export const ActionInspector: ComponentInspector<Action> = ({
         onChange={handleInputChange}
         dataPool={useEditorData().dataPool}
       />
-      <MultiNumberArray
+      <EffectSelector
         id="effects"
-        value={componentObject.effects.map(([a, b]) => [formatKeyAsDecimal(a), formatKeyAsDecimal(b)])}
+        value={componentObject.effects.map(([a, b]) => [a.toString(), b])}
         onChange={handleInputChange}
+        dataPool={useEditorData().dataPool}
       />
       <TextAreaArray
         id="failing_response"

--- a/packages/client/src/editor/components/inspectors/ActionInspector.tsx
+++ b/packages/client/src/editor/components/inspectors/ActionInspector.tsx
@@ -13,6 +13,7 @@ import type { ComponentInspector } from "./useInspector";
 import { useInspector } from "./useInspector";
 import { MultiNumberArray } from "../MultiNumberArray";
 import { TriggerSelector } from "../TriggerSelector";
+import { ConditionSelector } from "../ConditionSelector";
 import { BigNumberish } from "starknet";
 import { useEditorData } from "../../data/editor.data";
 
@@ -43,8 +44,10 @@ export const ActionInspector: ComponentInspector<Action> = ({
         ) as [BigNumberish, BigNumberish][];
       },
       conditions: (e, updatedObject) => {
-        const val = e.target.value as unknown as Array<[string, string]>;
-        updatedObject.conditions = val.map(
+        const val = e.target.value as unknown as Array<[string, BigNumberish]>;
+        updatedObject.conditions = val
+        .filter(([a, b]) => a !== "__placeholder__" && b !== "__placeholder__")
+        .map(
           ([a, b]) => [(a), (b)]
         ) as [BigNumberish, BigNumberish][];
       },
@@ -111,10 +114,11 @@ export const ActionInspector: ComponentInspector<Action> = ({
         onChange={handleInputChange}
         dataPool={useEditorData().dataPool}
       />
-      <MultiNumberArray
+      <ConditionSelector
         id="conditions"
-        value={componentObject.conditions.map(([a, b]) => [formatKeyAsDecimal(a), formatKeyAsDecimal(b)])}
+        value={componentObject.conditions.map(([a, b]) => [a.toString(), b])}
         onChange={handleInputChange}
+        dataPool={useEditorData().dataPool}
       />
       <MultiNumberArray
         id="effects"

--- a/packages/client/src/editor/data/editor.data.ts
+++ b/packages/client/src/editor/data/editor.data.ts
@@ -448,6 +448,10 @@ const updateSelectedEntity = (entity: EntityCollection) => {
 	set({ selectedEntity });
 };
 
+/**
+ * Creates a new entity with default inspectable component.
+ * @returns the new entity
+ */
 const newEntity = async () => {
 	const newEntity = createDefaultEntity();
 	syncItem(newEntity);
@@ -468,6 +472,10 @@ const newEntity = async () => {
 	return newEntity;
 };
 
+/**
+ * Creates a new player entity with the default components.
+ * @returns The new player entity
+ */
 export const newPlayer = async (): Promise<EntityCollection | undefined> => {
 	const spawnPoint = await getSpawnPoint();
 	if (spawnPoint === undefined) {
@@ -484,17 +492,11 @@ export const newPlayer = async (): Promise<EntityCollection | undefined> => {
 	await tick();
 
 	// parent will be the spawn point	
-	//const newParent = await getEntityAsync(spawnPoint);
 	const newParent = getEntity(spawnPoint)!;
-	console.log("newParent", newParent);
+	// console.log("newParent", newParent);
 	const children = playerEntity;
-	console.log("children", children);
+	// console.log("children", children);
 	await tick();
-	//const children2 = getEntity(playerEntity.Entity.inst)!;
-	// if (!newParent?.ParentToChildren) {
-	// 	console.error("newParent is missing ParentToChildren component:", newParent);
-	// 	return;
-	// }
 	if (!newParent || !children) {
 		console.error("Failed to retrieve parent or child entity after tick.", {
 			childId: playerEntity.Entity.inst,
@@ -569,6 +571,10 @@ export const syncPropertyRegistry = async (componentType: ComponentsEnum): Promi
 	return properties_array;
 };
 
+/**
+ * This handles fetching the spawn point from the first entity with an area component with is_spawn_point set to true
+ * @returns The spawn point entity inst
+ */
 export const getSpawnPoint = async(): Promise<BigNumberish> => {
 	let areaInst: BigNumberish;
 	try {
@@ -597,37 +603,11 @@ export const getSpawnPoint = async(): Promise<BigNumberish> => {
 	return areaInst;
 }
 
-export const getEntityAsync = async (id: BigNumberish): Promise<EntityCollection> => {
-	let entity: EntityCollection;
-	try {
-		const { sdk } = await InitDojo();
-		const queryEntity = () => {
-			const builder = new ToriiQueryBuilder<SchemaType>();
-			return builder
-				.withCursor("")
-				.withLimit(1000)
-				.includeHashedKeys()
-		};
-
-		const result = await sdk.getEntities({ query: queryEntity() });
-		const targetId = id;
-
-		result.getItems().forEach((item) => {
-			const posEntity = item.models?.lore?.Entity;
-			if (posEntity?.inst === targetId) {
-				entity = item.models?.lore as EntityCollection;
-				console.log("Found entity:", entity);
-			}
-		});
-
-	} catch (error) {
-		console.error("Error fetching entity from Torii:", error);
-		throw error;
-	}
-	if (!entity) console.warn(`Entity with ID ${id} not found in query.`);
-	return entity;
-};
-
+/**
+ * Checks if a player exists using the account address
+ * @param account The controller address of the player
+ * @returns True if the player exists, false otherwise
+ */
 export const getPlayer = async (account: string): Promise<boolean> => {
 	let playerFound = false;	
 	try {
@@ -656,6 +636,9 @@ export const getPlayer = async (account: string): Promise<boolean> => {
 export let playerFound = false;
 export let playerExists = false;
 
+/**
+ * Checks if a player exists and creates one if it doesn't
+ */
 export const checkForPlayer = async () => {
 	if (!playerExists) {
 		playerFound = await getPlayer(getPlayerAddress());


### PR DESCRIPTION
# Description

Replace the Number area with a dropdown list for setting up the triggers, conditions, and effects in the Action component in the FE.

## Related issues

Closes #105 #90 


## Introduced changes

The current changes are for replacing the setup of the action component on the editor:

- `trigger-entity-#`: dropdown list of all entities with a trigger component.
- `trigger- key-#`: dropdown list of all the key values of the triggers for the selected entity 
- `condition-entity-#`: dropdown list of all entities with a condition component.
- `condition- key-#`: dropdown list of all the key values of the conditions for the selected entity
- `effect-entity-#`: dropdown list of all entities with a effect component.
- `effect- key-#`: dropdown list of all the key values of the effects for the selected entity

This is done through three files added:

- `TriggerSelector.tsx`: get the all the entities with a trigger component and also the key values. Done using the `data pool`.
- `ConditionSelector.tsx`: get the all the entities with a condition component and also the key values. Done using the `data pool`.
- `EffectSelector.tsx`: get the all the entities with a effect component and also the key values. Done using the `data pool`.

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
