### PR TITLE
chore: implemented new models for text management

### DIFF
--- a/packages/contracts/src/lib/level_test.cairo
+++ b/packages/contracts/src/lib/level_test.cairo
@@ -1,8 +1,8 @@
 use dojo::{world::WorldStorage, model::ModelStorage};
 use lore::{
     models::{
-        index::{Entity, Area, Exit, Inspectable, DescriptionText}, components::Component, area::AreaComponent,
-        exit::ExitComponent, inspectable::InspectableComponent,
+        index::{Entity, Area, Exit, Inspectable, DescriptionText}, components::Component,
+        area::AreaComponent, exit::ExitComponent, inspectable::InspectableComponent,
     },
     new_components::entity_trait::EntityImpl,
 };
@@ -22,8 +22,12 @@ fn room_start(mut world: WorldStorage) {
     };
     world.write_model(@obj);
     let mut inspectable: Inspectable = Component::add_component(world, obj.inst);
-    let descr1 = DescriptionText { inst: 2826, key: 0 , text: "The first thing you've ever seen, it's pretty wild, flaring colors like flower petals but kaleidoscopically distorted"};
-    let descr2 = DescriptionText { inst: 2826, key: 1 , text: "Pretty colors"};
+    let descr1 = DescriptionText {
+        inst: 2826,
+        key: 0,
+        text: "The first thing you've ever seen, it's pretty wild, flaring colors like flower petals but kaleidoscopically distorted",
+    };
+    let descr2 = DescriptionText { inst: 2826, key: 1, text: "Pretty colors" };
     world.write_model(@descr1);
     world.write_model(@descr2);
     inspectable.description = array![0, 1];
@@ -42,8 +46,10 @@ fn object_room_one(mut world: WorldStorage, parent: Entity) {
     };
     world.write_model(@obj);
     let mut inspectable: Inspectable = Component::add_component(world, obj.inst);
-    let descr1 = DescriptionText { inst: 9999, key: 0 , text: "A portal"};
-    let descr2 = DescriptionText { inst: 9999, key: 1 , text: "A swirling circle of colors, it doesn't seem solid"};
+    let descr1 = DescriptionText { inst: 9999, key: 0, text: "A portal" };
+    let descr2 = DescriptionText {
+        inst: 9999, key: 1, text: "A swirling circle of colors, it doesn't seem solid",
+    };
     world.write_model(@descr1);
     world.write_model(@descr2);
     inspectable.description = array![0, 1];
@@ -61,15 +67,15 @@ fn room_two(mut world: WorldStorage) {
     entity.alt_names = array!["garden"];
     world.write_model(@entity);
     let mut inspectable: Inspectable = Component::add_component(world, entity.inst);
-    let descr1 = DescriptionText { inst: 1234, key: 0 , text: "Just suddenly it's all flowers and trees and grass"};
-    let descr2 = DescriptionText { inst: 1234, key: 1 , text: "Still pretty colors, but now it all has definition"};
+    let descr1 = DescriptionText {
+        inst: 1234, key: 0, text: "Just suddenly it's all flowers and trees and grass",
+    };
+    let descr2 = DescriptionText {
+        inst: 1234, key: 1, text: "Still pretty colors, but now it all has definition",
+    };
     world.write_model(@descr1);
     world.write_model(@descr2);
-    inspectable
-        .description =
-            array![
-                0, 1
-            ];
+    inspectable.description = array![0, 1];
     inspectable.store(world);
     let _: Area = Component::add_component(world, entity.inst);
 }

--- a/packages/contracts/src/lib/level_test.cairo
+++ b/packages/contracts/src/lib/level_test.cairo
@@ -1,7 +1,7 @@
 use dojo::{world::WorldStorage, model::ModelStorage};
 use lore::{
     models::{
-        index::{Entity, Area, Exit, Inspectable}, components::Component, area::AreaComponent,
+        index::{Entity, Area, Exit, Inspectable, DescriptionText}, components::Component, area::AreaComponent,
         exit::ExitComponent, inspectable::InspectableComponent,
     },
     new_components::entity_trait::EntityImpl,
@@ -22,12 +22,11 @@ fn room_start(mut world: WorldStorage) {
     };
     world.write_model(@obj);
     let mut inspectable: Inspectable = Component::add_component(world, obj.inst);
-    inspectable
-        .description =
-            array![
-                "The first thing you've ever seen, it's pretty wild, flaring colors like flower petals but kaleidoscopically distorted",
-                "Pretty colors",
-            ];
+    let descr1 = DescriptionText { inst: 2826, key: 0 , text: "The first thing you've ever seen, it's pretty wild, flaring colors like flower petals but kaleidoscopically distorted"};
+    let descr2 = DescriptionText { inst: 2826, key: 1 , text: "Pretty colors"};
+    world.write_model(@descr1);
+    world.write_model(@descr2);
+    inspectable.description = array![0, 1];
     inspectable.store(world);
     let _: Area = Component::add_component(world, obj.inst);
     object_room_one(world, obj);
@@ -43,7 +42,11 @@ fn object_room_one(mut world: WorldStorage, parent: Entity) {
     };
     world.write_model(@obj);
     let mut inspectable: Inspectable = Component::add_component(world, obj.inst);
-    inspectable.description = array!["A swirling circle of colors, it doesn't seem solid"];
+    let descr1 = DescriptionText { inst: 9999, key: 0 , text: "A portal"};
+    let descr2 = DescriptionText { inst: 9999, key: 1 , text: "A swirling circle of colors, it doesn't seem solid"};
+    world.write_model(@descr1);
+    world.write_model(@descr2);
+    inspectable.description = array![0, 1];
     inspectable.store(world);
     let mut exit: Exit = Component::add_component(world, obj.inst);
     exit.leads_to = 1234;
@@ -58,11 +61,14 @@ fn room_two(mut world: WorldStorage) {
     entity.alt_names = array!["garden"];
     world.write_model(@entity);
     let mut inspectable: Inspectable = Component::add_component(world, entity.inst);
+    let descr1 = DescriptionText { inst: 1234, key: 0 , text: "Just suddenly it's all flowers and trees and grass"};
+    let descr2 = DescriptionText { inst: 1234, key: 1 , text: "Still pretty colors, but now it all has definition"};
+    world.write_model(@descr1);
+    world.write_model(@descr2);
     inspectable
         .description =
             array![
-                "Just suddenly it's all flowers and trees and grass",
-                "Still pretty colors, but now it all has definition",
+                0, 1
             ];
     inspectable.store(world);
     let _: Area = Component::add_component(world, entity.inst);

--- a/packages/contracts/src/lib/variable_property.cairo
+++ b/packages/contracts/src/lib/variable_property.cairo
@@ -54,7 +54,7 @@ pub impl VariablePropertyImp of VariablePropertyTrait {
                 let prop_text = property_name.clone();
                 let (property_value_opt, access_opt) =
                     VariablePropertyHelperTrait::get_inspectable_property(
-                    component, @prop_text, @property_registry,
+                    component, @prop_text, @property_registry, *world,
                 );
                 property_value = property_value_opt;
                 access = access_opt;
@@ -99,7 +99,7 @@ pub impl VariablePropertyImp of VariablePropertyTrait {
         mut world: @WorldStorage,
         key: @felt252,
         property_name: @ByteArray,
-        new_value: @Array<ByteArray>,
+        new_value: @Array<(ByteArray, u32)>,
         component_type: ComponentType,
     ) -> Result<(), Error> {
         let property_registry: PropertyRegistry = world.read_model((component_type));

--- a/packages/contracts/src/lib/variable_property_helper.cairo
+++ b/packages/contracts/src/lib/variable_property_helper.cairo
@@ -492,7 +492,6 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
                                         inst: component.inst, key: index, text: value,
                                     };
                                     world.write_model(@new_desc);
-                                    component.description_counter += 1;
                                     component.description.append(index);
                                 };
                             };

--- a/packages/contracts/src/lib/variable_property_helper.cairo
+++ b/packages/contracts/src/lib/variable_property_helper.cairo
@@ -472,7 +472,7 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
                         } else if name == @description {
                             for (value, index) in new_value.clone() {
                                 // get description
-                                let mut descText: DescriptionText = world
+                                let mut descText: Option<DescriptionText> = world
                                     .read_model((component.inst.clone(), index));
                                 // update description
                                 descText.text = value;

--- a/packages/contracts/src/lib/variable_property_helper.cairo
+++ b/packages/contracts/src/lib/variable_property_helper.cairo
@@ -1,14 +1,18 @@
 use dojo::{world::{WorldStorage}, model::ModelStorage};
 use lore::{
     models::{
-        index::{Area, Exit, Inspectable, InventoryItem, Container, Player, PropertyRegistry},
+        index::{
+            Area, Exit, Inspectable, DescriptionText, InventoryItem, Container, Player,
+            PropertyRegistry,
+        },
         area::AreaComponent, exit::ExitComponent, inspectable::InspectableComponent,
         inventoryItem::InventoryItemComponent, container::ContainerComponent,
         player::PlayerComponent,
     },
     types::{
         property_type::{ComponentProperty, PropertyType, PropertyAccess},
-        component_type::ComponentType, direction_type::IntoDirectionByteArray,
+        component_type::ComponentType,
+        direction_type::{Direction, IntoDirectionByteArray, IntoFelt252Direction},
     },
     lib::{utils::ByteArrayTraitExt}, constants::errors::Error,
 };
@@ -219,7 +223,7 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
     }
 
     fn get_inspectable_property(
-        component: Inspectable, name: @ByteArray, property: @PropertyRegistry,
+        component: Inspectable, name: @ByteArray, property: @PropertyRegistry, world: WorldStorage,
     ) -> (Option<Array<felt252>>, Option<PropertyAccess>) {
         // Define expected property names
         let is_visible: ByteArray = "is_visible";
@@ -238,8 +242,9 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
                 } else if name == @description {
                     let desc = component.description;
                     for i in 0..desc.len() {
-                        let part: ByteArray = desc.at(i).clone();
-                        let felt = ByteArrayTraitExt::to_felt252_word(@part).unwrap();
+                        let key: u32 = desc.at(i).clone();
+                        let descText: DescriptionText = world.read_model((component.inst, key));
+                        let felt = ByteArrayTraitExt::to_felt252_word(@descText.text).unwrap();
                         arr.append(felt);
                     }
                 }
@@ -347,7 +352,7 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
         mut world: WorldStorage,
         name: @ByteArray,
         property: @PropertyRegistry,
-        new_value: @Array<ByteArray>,
+        new_value: @Array<(ByteArray, u32)>,
     ) -> (Result::<(), Error>, bool) {
         // Define expected property names
         let is_area: ByteArray = "is_area";
@@ -365,9 +370,8 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
                     },
                     PropertyAccess::ReadWrite => {
                         if name == @is_spawn_point {
-                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.is_spawn_point = new_var_value;
                             success = true;
                         }
@@ -385,7 +389,7 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
         mut world: WorldStorage,
         name: @ByteArray,
         property: @PropertyRegistry,
-        new_value: @Array<ByteArray>,
+        new_value: @Array<(ByteArray, u32)>,
     ) -> (Result::<(), Error>, bool) {
         // Define expected property names
         let is_exit: ByteArray = "is_exit";
@@ -401,29 +405,29 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
                     PropertyAccess::ReadOnly => { result = Result::Err(Error::ReadOnlyVariable); },
                     PropertyAccess::ReadWrite => {
                         if name == @is_exit {
-                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.is_exit = new_var_value;
                             success = true;
                         } else if name == @is_enterable {
-                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.is_enterable = new_var_value;
                             success = true;
                         } else if name == @leads_to {
-                            component
-                                .leads_to =
-                                    ByteArrayTraitExt::to_felt252_word(@new_value[0].clone())
-                                .unwrap();
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::to_felt252_word(@value).unwrap();
+                            component.leads_to = new_var_value;
                             success = true;
                         } else if name == @direction_type {
-                            let new_dir = ByteArrayTraitExt::direction_from_felt252(
-                                ByteArrayTraitExt::to_felt252_word(
-                                    @ByteArrayTraitExt::to_lowercase(new_value[0].clone()),
-                                )
-                                    .unwrap(),
+                            let (value, _index) = new_value[0].clone();
+                            let lowercased = ByteArrayTraitExt::to_lowercase(value);
+                            let to_felt252_direction = ByteArrayTraitExt::to_felt252_word(
+                                @lowercased,
+                            )
+                                .unwrap();
+                            let new_dir: Direction = IntoFelt252Direction::into(
+                                to_felt252_direction,
                             );
                             component.direction_type = new_dir;
                             success = true;
@@ -442,7 +446,7 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
         mut world: WorldStorage,
         name: @ByteArray,
         property: @PropertyRegistry,
-        new_value: @Array<ByteArray>,
+        new_value: @Array<(ByteArray, u32)>,
     ) -> (Result::<(), Error>, bool) {
         // Define expected property names
         let is_visible: ByteArray = "is_visible";
@@ -456,29 +460,24 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
                     PropertyAccess::ReadOnly => { result = Result::Err(Error::ReadOnlyVariable); },
                     PropertyAccess::ReadWrite => {
                         if name == @is_visible {
-                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.is_visible = new_var_value;
                             success = true;
                         } else if name == @is_inspectable {
-                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.is_inspectable = new_var_value;
                             success = true;
                         } else if name == @description {
-                            // FOR NOW REPLACES THE WHOLE ARRAY,
-                            // TODO: implement a way that supports updating/replacing/removing at
-                            // certain indices Build a temporary mutable copy of description
-                            let mut new_description = array![];
-
-                            // Copy the original description
-                            for item in new_value.clone() {
-                                let new_byte = item;
-                                new_description.append(new_byte.clone());
+                            for (value, index) in new_value.clone() {
+                                // get description
+                                let mut descText: DescriptionText = world
+                                    .read_model((component.inst.clone(), index));
+                                // update description
+                                descText.text = value;
+                                world.write_model(@descText);
                             };
-                            component.description = new_description;
                             success = true;
                         }
                     },
@@ -495,7 +494,7 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
         mut world: WorldStorage,
         name: @ByteArray,
         property: @PropertyRegistry,
-        new_value: @Array<ByteArray>,
+        new_value: @Array<(ByteArray, u32)>,
     ) -> (Result::<(), Error>, bool) {
         // Define expected property names
         let owner_id: ByteArray = "owner_id";
@@ -512,30 +511,27 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
                     PropertyAccess::ReadOnly => { result = Result::Err(Error::ReadOnlyVariable); },
                     PropertyAccess::ReadWrite => {
                         if name == @owner_id {
-                            component.owner_id = new_value[0].to_felt252_word().unwrap();
+                            let (value, _index) = new_value[0].clone();
+                            component.owner_id = value.to_felt252_word().unwrap();
                             success = true;
                         } else if name == @can_be_picked_up {
-                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.can_be_picked_up = new_var_value;
                             success = true;
                         } else if name == @can_go_in_container {
-                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.can_go_in_container = new_var_value;
                             success = true;
                         } else if name == @already_used {
-                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.already_used = new_var_value;
                             success = true;
                         } else if name == @multiple_use {
-                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.multiple_use = new_var_value;
                             success = true;
                         }
@@ -553,7 +549,7 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
         mut world: WorldStorage,
         name: @ByteArray,
         property: @PropertyRegistry,
-        new_value: @Array<ByteArray>,
+        new_value: @Array<(ByteArray, u32)>,
     ) -> (Result::<(), Error>, bool) {
         // Define expected property names
         let is_container: ByteArray = "is_container";
@@ -570,33 +566,28 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
                     PropertyAccess::ReadOnly => { result = Result::Err(Error::ReadOnlyVariable); },
                     PropertyAccess::ReadWrite => {
                         if name == @is_container {
-                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.is_container = new_var_value;
                             success = true;
                         } else if name == @can_be_opened {
-                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.can_be_opened = new_var_value;
                             success = true;
                         } else if name == @can_receive_items {
-                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.can_receive_items = new_var_value;
                             success = true;
                         } else if name == @is_open {
-                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.is_open = new_var_value;
                             success = true;
                         } else if name == @num_slots {
-                            let new_var_value = ByteArrayTraitExt::u32_from_byte_array(
-                                new_value[0].clone(),
-                            );
+                            let (value, _index) = new_value[0].clone();
+                            let new_var_value = ByteArrayTraitExt::u32_from_byte_array(value);
                             component.num_slots = new_var_value;
                             success = true;
                         }
@@ -614,7 +605,7 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
         mut world: WorldStorage,
         name: @ByteArray,
         property: @PropertyRegistry,
-        new_value: @Array<ByteArray>,
+        new_value: @Array<(ByteArray, u32)>,
     ) -> (Result::<(), Error>, bool) {
         // Define expected property names
         let location: ByteArray = "location";
@@ -627,8 +618,9 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
                     PropertyAccess::ReadOnly => { result = Result::Err(Error::ReadOnlyVariable); },
                     PropertyAccess::ReadWrite => {
                         if name == @location {
+                            let (value, _index) = new_value[0].clone();
                             component
-                                .location = ByteArrayTraitExt::to_felt252_word(new_value[0])
+                                .location = ByteArrayTraitExt::to_felt252_word(@value)
                                 .unwrap();
                             success = true;
                         }

--- a/packages/contracts/src/lib/variable_property_helper.cairo
+++ b/packages/contracts/src/lib/variable_property_helper.cairo
@@ -471,12 +471,30 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
                             success = true;
                         } else if name == @description {
                             for (value, index) in new_value.clone() {
-                                // get description
-                                let mut descText: Option<DescriptionText> = world
-                                    .read_model((component.inst.clone(), index));
-                                // update description
-                                descText.text = value;
-                                world.write_model(@descText);
+                                let mut found: bool = false;
+
+                                // Check if index is already in component.description
+                                for key in component.description.clone() {
+                                    if key == index {
+                                        // Update existing description
+                                        let mut descText: DescriptionText = world
+                                            .read_model((component.inst.clone(), index));
+                                        descText.text = value.clone();
+                                        world.write_model(@descText);
+                                        found = true;
+                                        break;
+                                    }
+                                };
+
+                                if !found {
+                                    // Add new description
+                                    let new_desc = DescriptionText {
+                                        inst: component.inst, key: index, text: value,
+                                    };
+                                    world.write_model(@new_desc);
+                                    component.description_counter += 1;
+                                    component.description.append(index);
+                                };
                             };
                             success = true;
                         }

--- a/packages/contracts/src/models/index.cairo
+++ b/packages/contracts/src/models/index.cairo
@@ -81,8 +81,6 @@ pub struct Inspectable {
     pub is_visible: bool,
     /// Array of descriptions for the inspectable
     pub description: Array<u32>,
-    /// Counter to know how many descriptions are there
-    pub description_counter: u32,
     /// Array of action maps for the inspectable
     pub action_map: Array<ActionMapInspectable>,
     /// For the first description, if we want to show a different one

--- a/packages/contracts/src/models/index.cairo
+++ b/packages/contracts/src/models/index.cairo
@@ -309,8 +309,9 @@ pub struct Effect {
     pub component: ComponentType,
     /// Property to modify
     pub property: ByteArray,
-    /// New value to set, needs to be array for multiple values such as description.
-    pub value: Array<ByteArray>,
+    /// New value to set, needs to be tuple array. First element is the value, second is the index
+    /// (for texts).
+    pub value: Array<(ByteArray, u32)>,
 }
 
 /// NOT USED YET ///

--- a/packages/contracts/src/models/index.cairo
+++ b/packages/contracts/src/models/index.cairo
@@ -80,13 +80,26 @@ pub struct Inspectable {
     /// If the inspectable is visible
     pub is_visible: bool,
     /// Array of descriptions for the inspectable
-    pub description: Array<ByteArray>,
+    pub description: Array<u32>,
     /// Array of action maps for the inspectable
     pub action_map: Array<ActionMapInspectable>,
     /// For the first description, if we want to show a different one
     pub already_shown: bool,
     /// New first description
     pub new_entry: ByteArray,
+}
+
+#[derive(Clone, Drop, Serde, Introspect, PartialEq, Debug)]
+#[dojo::model]
+pub struct DescriptionText {
+    /// Unique identifier from the Entity it is attached to
+    #[key]
+    pub inst: felt252,
+    /// Unique identifier of the description
+    #[key]
+    pub key: u32,
+    /// Description text
+    pub text: ByteArray,
 }
 
 #[derive(Clone, Drop, Serde, Introspect, PartialEq, Debug)]

--- a/packages/contracts/src/models/index.cairo
+++ b/packages/contracts/src/models/index.cairo
@@ -81,6 +81,8 @@ pub struct Inspectable {
     pub is_visible: bool,
     /// Array of descriptions for the inspectable
     pub description: Array<u32>,
+    /// Counter to know how many descriptions are there
+    pub description_counter: u32,
     /// Array of action maps for the inspectable
     pub action_map: Array<ActionMapInspectable>,
     /// For the first description, if we want to show a different one

--- a/packages/contracts/src/models/index.cairo
+++ b/packages/contracts/src/models/index.cairo
@@ -157,6 +157,8 @@ pub struct Player {
     pub address: ContractAddress,
     /// The location of the player
     pub location: felt252,
+    /// Current story line
+    pub story_line: CounterType,
     /// If the player is in debug mode
     pub use_debug: bool,
 }
@@ -167,8 +169,22 @@ pub struct PlayerStory {
     #[key]
     pub inst: felt252,
     /// Properties ///
-    /// Array of story lines
-    pub story: Array<ByteArray>,
+    /// Array of story lines (story lines keys)
+    pub story: Array<CounterType>,
+}
+
+pub type CounterType = u64;
+#[derive(Clone, Drop, Serde, Debug, Introspect, PartialEq)]
+#[dojo::model]
+pub struct StoryLine {
+    /// Unique identifier (Player or PlayerStory)
+    #[key]
+    pub inst: felt252,
+    /// Unique identifier of the line
+    #[key]
+    pub key: CounterType,
+    /// Story line
+    pub line: ByteArray,
 }
 
 #[derive(Clone, Drop, Serde, Introspect, Debug, PartialEq)]

--- a/packages/contracts/src/models/inspectable.cairo
+++ b/packages/contracts/src/models/inspectable.cairo
@@ -99,7 +99,7 @@ pub impl InspectableComponent of Component<Inspectable> {
                 // Get idx from the action map entrypoint
                 let idx: u32 = action.entrypoint.try_into().unwrap();
                 // Say the description
-                player.say(world, InspectableImpl::get_specific_description(@self, idx));
+                player.say(world, InspectableImpl::get_specific_description(@self, idx, world));
                 return Result::Ok(());
             },
         }
@@ -134,23 +134,25 @@ mod tests {
     use dojo::{world::WorldStorage, model::ModelStorage};
     use super::*;
     use lore::tests::helpers;
-    use lore::{models::index::Inspectable, new_components::inspectable_trait::InspectableImpl};
+    use lore::{models::index::{Inspectable, DescriptionText}, new_components::inspectable_trait::InspectableImpl};
 
     fn Inspectable_create_prefab() -> (
         Inspectable, WorldStorage, ContractAddress, ContractAddress,
     ) {
         let (mut world, _, _, player_1, player_2) = helpers::setup_core();
+
+        let descr1 = DescriptionText { inst: 42, key: 0 , text: "hello"};
+        let descr2 = DescriptionText { inst: 42, key: 1 , text: "world"};
+        let descr3 = DescriptionText { inst: 42, key: 2 , text: "how big is a rock"};
+        let descr4 = DescriptionText { inst: 42, key: 3 , text: "what's up with the rock"};
+        let descr5 = DescriptionText { inst: 42, key: 4 , text: "let's talk about the rock"};
+        let descr6 = DescriptionText { inst: 42, key: 5 , text: "the rock is from the moon"};
         let prefab = Inspectable {
             inst: 42,
             is_inspectable: true,
             is_visible: true,
             description: array![
-                "hello",
-                "world",
-                "how big is a rock",
-                "what's up with the rock",
-                "let's talk about the rock",
-                "the rock is from the moon",
+                0, 1, 2, 3, 4, 5
             ],
             action_map: array![
                 ActionMapInspectable {

--- a/packages/contracts/src/models/inspectable.cairo
+++ b/packages/contracts/src/models/inspectable.cairo
@@ -161,6 +161,7 @@ mod tests {
             is_inspectable: true,
             is_visible: true,
             description: array![0, 1, 2, 3, 4, 5],
+            description_counter: 6,
             action_map: array![
                 ActionMapInspectable {
                     action: "show",

--- a/packages/contracts/src/models/inspectable.cairo
+++ b/packages/contracts/src/models/inspectable.cairo
@@ -150,6 +150,12 @@ mod tests {
         let descr4 = DescriptionText { inst: 42, key: 3, text: "what's up with the rock" };
         let descr5 = DescriptionText { inst: 42, key: 4, text: "let's talk about the rock" };
         let descr6 = DescriptionText { inst: 42, key: 5, text: "the rock is from the moon" };
+        world.write_model(@descr1);
+        world.write_model(@descr2);
+        world.write_model(@descr3);
+        world.write_model(@descr4);
+        world.write_model(@descr5);
+        world.write_model(@descr6);
         let prefab = Inspectable {
             inst: 42,
             is_inspectable: true,
@@ -207,7 +213,7 @@ mod tests {
         let (prefab, world, _, _) = Inspectable_create_prefab();
         let i: Inspectable = Component::get_component(world, prefab.inst).unwrap();
         let idx: u32 = 5;
-        let res = InspectableImpl::get_specific_description(@i, idx);
+        let res = InspectableImpl::get_specific_description(@i, idx, world);
         assert(res == "the rock is from the moon", 'description should be the moon');
     }
 }

--- a/packages/contracts/src/models/inspectable.cairo
+++ b/packages/contracts/src/models/inspectable.cairo
@@ -161,7 +161,6 @@ mod tests {
             is_inspectable: true,
             is_visible: true,
             description: array![0, 1, 2, 3, 4, 5],
-            description_counter: 6,
             action_map: array![
                 ActionMapInspectable {
                     action: "show",

--- a/packages/contracts/src/models/inspectable.cairo
+++ b/packages/contracts/src/models/inspectable.cairo
@@ -134,26 +134,27 @@ mod tests {
     use dojo::{world::WorldStorage, model::ModelStorage};
     use super::*;
     use lore::tests::helpers;
-    use lore::{models::index::{Inspectable, DescriptionText}, new_components::inspectable_trait::InspectableImpl};
+    use lore::{
+        models::index::{Inspectable, DescriptionText},
+        new_components::inspectable_trait::InspectableImpl,
+    };
 
     fn Inspectable_create_prefab() -> (
         Inspectable, WorldStorage, ContractAddress, ContractAddress,
     ) {
         let (mut world, _, _, player_1, player_2) = helpers::setup_core();
 
-        let descr1 = DescriptionText { inst: 42, key: 0 , text: "hello"};
-        let descr2 = DescriptionText { inst: 42, key: 1 , text: "world"};
-        let descr3 = DescriptionText { inst: 42, key: 2 , text: "how big is a rock"};
-        let descr4 = DescriptionText { inst: 42, key: 3 , text: "what's up with the rock"};
-        let descr5 = DescriptionText { inst: 42, key: 4 , text: "let's talk about the rock"};
-        let descr6 = DescriptionText { inst: 42, key: 5 , text: "the rock is from the moon"};
+        let descr1 = DescriptionText { inst: 42, key: 0, text: "hello" };
+        let descr2 = DescriptionText { inst: 42, key: 1, text: "world" };
+        let descr3 = DescriptionText { inst: 42, key: 2, text: "how big is a rock" };
+        let descr4 = DescriptionText { inst: 42, key: 3, text: "what's up with the rock" };
+        let descr5 = DescriptionText { inst: 42, key: 4, text: "let's talk about the rock" };
+        let descr6 = DescriptionText { inst: 42, key: 5, text: "the rock is from the moon" };
         let prefab = Inspectable {
             inst: 42,
             is_inspectable: true,
             is_visible: true,
-            description: array![
-                0, 1, 2, 3, 4, 5
-            ],
+            description: array![0, 1, 2, 3, 4, 5],
             action_map: array![
                 ActionMapInspectable {
                     action: "show",

--- a/packages/contracts/src/models/player.cairo
+++ b/packages/contracts/src/models/player.cairo
@@ -102,8 +102,8 @@ mod tests {
         assert(story.story.len() == 2, 'story has two entries'); // first entry is intro text
         let test_text: ByteArray = "hello";
 
-        let story_key:u64 = *story.story.at(story.story.len() - 1);
-        let story_line:StoryLine = world.read_model((story.inst, story_key));
+        let story_key: u64 = *story.story.at(story.story.len() - 1);
+        let story_line: StoryLine = world.read_model((story.inst, story_key));
         assert(story_line.line == test_text, 'story has "hello"');
     }
 }

--- a/packages/contracts/src/models/player.cairo
+++ b/packages/contracts/src/models/player.cairo
@@ -79,7 +79,7 @@ pub fn caller_as_player(world: WorldStorage, address: ContractAddress) -> Player
 mod tests {
     use dojo::{model::ModelStorage};
     use lore::{
-        models::{index::{Player, PlayerStory}, player::caller_as_player},
+        models::{index::{Player, PlayerStory, StoryLine}, player::caller_as_player},
         new_components::player_trait::{PlayerImpl}, tests::helpers,
     };
 
@@ -101,6 +101,9 @@ mod tests {
         // ("story: {:?}", story);
         assert(story.story.len() == 2, 'story has two entries'); // first entry is intro text
         let test_text: ByteArray = "hello";
-        assert(story.story.at(story.story.len() - 1) == @test_text, 'story has "hello"');
+
+        let story_key:u64 = *story.story.at(story.story.len() - 1);
+        let story_line:StoryLine = world.read_model((story.inst, story_key));
+        assert(story_line.line == test_text, 'story has "hello"');
     }
 }

--- a/packages/contracts/src/new_components/action_trait.cairo
+++ b/packages/contracts/src/new_components/action_trait.cairo
@@ -158,8 +158,8 @@ mod tests {
     use lore::{
         models::{
             index::{
-                Entity, Area, Exit, Inspectable, InventoryItem, Container, Trigger, Condition,
-                Effect, Action,
+                Entity, Area, Exit, Inspectable, DescriptionText, InventoryItem, Container, Trigger,
+                Condition, Effect, Action,
             },
             area::AreaComponent, exit::ExitComponent, inspectable::InspectableComponent,
             inventoryItem::InventoryItemComponent, container::ContainerComponent,
@@ -216,9 +216,11 @@ mod tests {
         world.write_model(@door);
         // add inspectable component to door
         let mut inspectable: Inspectable = Component::add_component(world, door.inst);
+        let desc1: DescriptionText = DescriptionText { inst: door.inst, key: 0, text: "A door" };
+        world.write_model(@desc1);
         inspectable.is_inspectable = true;
         inspectable.is_visible = true;
-        inspectable.description = array!["A door"];
+        inspectable.description = array![0];
         inspectable
             .action_map =
                 array![
@@ -263,9 +265,11 @@ mod tests {
         world.write_model(@item);
         // add inspectable component to item
         let mut inspectable: Inspectable = Component::add_component(world, item.inst);
+        let desc1: DescriptionText = DescriptionText { inst: item.inst, key: 0, text: "A ball" };
+        world.write_model(@desc1);
         inspectable.is_inspectable = true;
         inspectable.is_visible = true;
-        inspectable.description = array!["A ball"];
+        inspectable.description = array![0];
         inspectable
             .action_map =
                 array![
@@ -350,7 +354,7 @@ mod tests {
         target: felt252,
         component: ComponentType,
         property: ByteArray,
-        value: Array<ByteArray>,
+        value: Array<(ByteArray, u32)>,
     ) -> Effect {
         Effect { inst, key, name, target, component, property, value }
     }
@@ -418,6 +422,9 @@ mod tests {
         // create door entity in room 2 that leads to room 1 via south
         let mut door = create_door(world, room_1.inst, Direction::South);
         door.set_parent(world, @room_2);
+        let old_insp_door: Inspectable = world.read_model(door.inst);
+        let old_key: u32 = *old_insp_door.description.at(0);
+        let old_txt: DescriptionText = world.read_model((door.inst, old_key));
 
         // create item that is in room 1
         let mut item = create_item(world, room_1.inst);
@@ -461,15 +468,17 @@ mod tests {
         // New Description door -> Inspectable
         // 1. New description as bytearray
         let new_txt1: ByteArray = "A door that is open";
+        let idx1: u32 = 0;
         let new_txt2: ByteArray = "Looks that it leads somewhere";
+        let idx2: u32 = 1;
         // 2. Create array of the new description
-        let new_description: Array<ByteArray> = array![new_txt1, new_txt2];
+        let new_description: Array<(ByteArray, u32)> = array![(new_txt1.clone(), idx1), (new_txt2.clone(), idx2)];
 
         // New is_enterable -> Exit
         // 1. New value as bytearray
         let enterable: ByteArray = "true";
         // 2. Create array of the new value
-        let new_enterable: Array<ByteArray> = array![enterable];
+        let new_enterable: Array<(ByteArray, u32)> = array![(enterable, 0)];
 
         // Properties as bytearray
         let property: ByteArray = "description";
@@ -561,12 +570,12 @@ mod tests {
         // 3. Effects should not be update
         let upd_door: Inspectable = world.read_model(door.inst);
         let upd_door_exit: Exit = world.read_model(door.inst);
-        let new_text1 = new_description.at(0);
-        let _new_text2 = new_description.at(1);
+        let key1: u32 = *upd_door.description.at(0);
+        // let key2: u32 = *new_description.at(1);
+        let new_text1: DescriptionText = world.read_model((upd_door.inst, key1));
+        // let _new_text2: DescriptionText = world.read_model((upd_door.inst, key2));
         assert_ne!(
-            upd_door.description[0].clone(),
-            new_text1.clone(),
-            "Description1 should not be updated",
+            new_txt1.clone(), new_text1.text.clone(), "Description1 should not be updated",
         );
         // This one fails as there is no index 1 in the array
         //assert_ne!(upd_door.description[1].clone(), new_text2, "Description2 should not be
@@ -640,15 +649,19 @@ mod tests {
         // New Description door -> Inspectable
         // 1. New description as bytearray
         let new_txt1: ByteArray = "A door that is open";
+        let idx1: u32 = 0;
         let new_txt2: ByteArray = "Looks that it leads somewhere";
+        let idx2: u32 = 1;
         // 2. Create array of the new description
-        let new_description: Array<ByteArray> = array![new_txt1, new_txt2];
+        let new_description: Array<(ByteArray, u32)> = array![
+            (new_txt1.clone(), idx1), (new_txt2.clone(), idx2),
+        ];
 
         // New is_enterable -> Exit
         // 1. New value as ByteArray
         let enterable: ByteArray = "true";
         // 2. Create array of the new value
-        let new_enterable: Array<ByteArray> = array![enterable];
+        let new_enterable: Array<(ByteArray, u32)> = array![(enterable, 0)];
 
         // Properties as bytearray
         let property: ByteArray = "description";
@@ -759,14 +772,12 @@ mod tests {
         // 3. Effects should be update
         let upd_door: Inspectable = world.read_model(door.inst);
         let upd_door_exit: Exit = world.read_model(door.inst);
-        let new_text1 = new_description.at(0);
-        let new_text2 = new_description.at(1);
-        assert_eq!(
-            upd_door.description[0].clone(), new_text1.clone(), "Description1 should be updated",
-        );
-        assert_eq!(
-            upd_door.description[1].clone(), new_text2.clone(), "Description2 should be updated",
-        );
+        let key1: u32 = *upd_door.description.at(0);
+        let key2: u32 = *upd_door.description.at(1);
+        let new_text1: DescriptionText = world.read_model((upd_door.inst, key1));
+        let new_text2: DescriptionText = world.read_model((upd_door.inst, key2));
+        assert_eq!(new_txt1, new_text1.text.clone(), "Description1 should be updated");
+        assert_eq!(new_txt2, new_text2.text.clone(), "Description2 should be updated");
         assert(upd_door_exit.is_enterable == true, 'Exit should be updated');
         // println!("Old description: {:?}", old_inspectable.description);
     // println!("New description: {:?}", array![new_text1, new_text2]);

--- a/packages/contracts/src/new_components/action_trait.cairo
+++ b/packages/contracts/src/new_components/action_trait.cairo
@@ -218,7 +218,6 @@ mod tests {
         let mut inspectable: Inspectable = Component::add_component(world, door.inst);
         let desc1: DescriptionText = DescriptionText { inst: door.inst, key: 0, text: "A door" };
         world.write_model(@desc1);
-        inspectable.description_counter += 1;
         inspectable.is_inspectable = true;
         inspectable.is_visible = true;
         inspectable.description = array![0];
@@ -268,7 +267,6 @@ mod tests {
         let mut inspectable: Inspectable = Component::add_component(world, item.inst);
         let desc1: DescriptionText = DescriptionText { inst: item.inst, key: 0, text: "A ball" };
         world.write_model(@desc1);
-        inspectable.description_counter += 1;
         inspectable.is_inspectable = true;
         inspectable.is_visible = true;
         inspectable.description = array![0];
@@ -426,7 +424,7 @@ mod tests {
         door.set_parent(world, @room_2);
         let old_insp_door: Inspectable = world.read_model(door.inst);
         let old_key: u32 = *old_insp_door.description.at(0);
-        let old_txt: DescriptionText = world.read_model((door.inst, old_key));
+        let _old_txt: DescriptionText = world.read_model((door.inst, old_key));
 
         // create item that is in room 1
         let mut item = create_item(world, room_1.inst);

--- a/packages/contracts/src/new_components/action_trait.cairo
+++ b/packages/contracts/src/new_components/action_trait.cairo
@@ -218,6 +218,7 @@ mod tests {
         let mut inspectable: Inspectable = Component::add_component(world, door.inst);
         let desc1: DescriptionText = DescriptionText { inst: door.inst, key: 0, text: "A door" };
         world.write_model(@desc1);
+        inspectable.description_counter += 1;
         inspectable.is_inspectable = true;
         inspectable.is_visible = true;
         inspectable.description = array![0];
@@ -267,6 +268,7 @@ mod tests {
         let mut inspectable: Inspectable = Component::add_component(world, item.inst);
         let desc1: DescriptionText = DescriptionText { inst: item.inst, key: 0, text: "A ball" };
         world.write_model(@desc1);
+        inspectable.description_counter += 1;
         inspectable.is_inspectable = true;
         inspectable.is_visible = true;
         inspectable.description = array![0];
@@ -472,7 +474,9 @@ mod tests {
         let new_txt2: ByteArray = "Looks that it leads somewhere";
         let idx2: u32 = 1;
         // 2. Create array of the new description
-        let new_description: Array<(ByteArray, u32)> = array![(new_txt1.clone(), idx1), (new_txt2.clone(), idx2)];
+        let new_description: Array<(ByteArray, u32)> = array![
+            (new_txt1.clone(), idx1), (new_txt2.clone(), idx2),
+        ];
 
         // New is_enterable -> Exit
         // 1. New value as bytearray
@@ -574,9 +578,7 @@ mod tests {
         // let key2: u32 = *new_description.at(1);
         let new_text1: DescriptionText = world.read_model((upd_door.inst, key1));
         // let _new_text2: DescriptionText = world.read_model((upd_door.inst, key2));
-        assert_ne!(
-            new_txt1.clone(), new_text1.text.clone(), "Description1 should not be updated",
-        );
+        assert_ne!(new_txt1.clone(), new_text1.text.clone(), "Description1 should not be updated");
         // This one fails as there is no index 1 in the array
         //assert_ne!(upd_door.description[1].clone(), new_text2, "Description2 should not be
         //updated");

--- a/packages/contracts/src/new_components/condition_trait.cairo
+++ b/packages/contracts/src/new_components/condition_trait.cairo
@@ -159,7 +159,7 @@ mod tests {
     use lore::tests::helpers;
     use lore::{
         models::{
-            index::{Inspectable, Condition}, components::Component,
+            index::{Inspectable, DescriptionText, Condition}, components::Component,
             inspectable::InspectableComponent,
         },
         new_components::entity_trait::EntityImpl,
@@ -190,10 +190,14 @@ mod tests {
 
         let new_entry: ByteArray = "A door";
         let mut inspectable: Inspectable = Component::add_component(world, door.inst);
+        let desc1: DescriptionText = DescriptionText {
+            inst: door.inst, key: 0, text: new_entry.clone(),
+        };
+        world.write_model(@desc1);
         inspectable.is_inspectable = true;
         inspectable.is_visible = true;
         inspectable.already_shown = false;
-        inspectable.description = array!["A door"];
+        inspectable.description = array![0];
         inspectable.new_entry = new_entry;
         inspectable
             .action_map =

--- a/packages/contracts/src/new_components/effect_trait.cairo
+++ b/packages/contracts/src/new_components/effect_trait.cairo
@@ -153,6 +153,7 @@ mod tests {
         let mut inspectable: Inspectable = Component::add_component(world, door.inst);
         let desc1: DescriptionText = DescriptionText { inst: door.inst, key: 0, text: "A door" };
         world.write_model(@desc1);
+        inspectable.description_counter += 1;
         inspectable.is_inspectable = true;
         inspectable.is_visible = true;
         inspectable.description = array![0];

--- a/packages/contracts/src/new_components/effect_trait.cairo
+++ b/packages/contracts/src/new_components/effect_trait.cairo
@@ -153,7 +153,6 @@ mod tests {
         let mut inspectable: Inspectable = Component::add_component(world, door.inst);
         let desc1: DescriptionText = DescriptionText { inst: door.inst, key: 0, text: "A door" };
         world.write_model(@desc1);
-        inspectable.description_counter += 1;
         inspectable.is_inspectable = true;
         inspectable.is_visible = true;
         inspectable.description = array![0];

--- a/packages/contracts/src/new_components/effect_trait.cairo
+++ b/packages/contracts/src/new_components/effect_trait.cairo
@@ -111,8 +111,9 @@ mod tests {
     use lore::tests::helpers;
     use lore::{
         models::{
-            index::{Inspectable, Player}, components::Component, area::AreaComponent,
-            inspectable::InspectableComponent, player::{PlayerComponent, caller_as_player},
+            index::{Inspectable, DescriptionText, Player}, components::Component,
+            area::AreaComponent, inspectable::InspectableComponent,
+            player::{PlayerComponent, caller_as_player},
         },
         new_components::{
             entity_trait::EntityImpl, player_trait::PlayerImpl, trigger_trait::TriggerImpl,
@@ -131,7 +132,7 @@ mod tests {
         target: felt252,
         component: ComponentType,
         property: ByteArray,
-        value: Array<ByteArray>,
+        value: Array<(ByteArray, u32)>,
     ) -> Effect {
         Effect { inst, key, name, target, component, property, value }
     }
@@ -150,9 +151,11 @@ mod tests {
         door.name = "door";
         world.write_model(@door);
         let mut inspectable: Inspectable = Component::add_component(world, door.inst);
+        let desc1: DescriptionText = DescriptionText { inst: door.inst, key: 0, text: "A door" };
+        world.write_model(@desc1);
         inspectable.is_inspectable = true;
         inspectable.is_visible = true;
-        inspectable.description = array!["A door"];
+        inspectable.description = array![0];
         inspectable
             .action_map =
                 array![
@@ -170,6 +173,9 @@ mod tests {
                     },
                 ];
         inspectable.store(world);
+        let old_insp_door: Inspectable = world.read_model(door.inst);
+        let old_key: u32 = *old_insp_door.description.at(0);
+        let old_txt: DescriptionText = world.read_model((door.inst, old_key));
 
         // Create player
         let mut player: Player = caller_as_player(world, player_1);
@@ -182,8 +188,8 @@ mod tests {
         VariablePropertyImp::register_component_properties(world, ComponentType::Inspectable);
 
         // Test description new value
-        let new_value: Array<ByteArray> = array![
-            "A door that is open", "Looks that it leads somewhere",
+        let new_value: Array<(ByteArray, u32)> = array![
+            ("A door that is open", 0), ("Looks that it leads somewhere", 1),
         ];
         let key: felt252 = 1;
         let name: ByteArray = "Effect name";
@@ -200,15 +206,15 @@ mod tests {
         let result = effect.apply_effect(world, context);
 
         let new_inspectable: Inspectable = world.read_model(door.inst);
+        let key: u32 = *new_inspectable.description.at(0);
+        let key2: u32 = *new_inspectable.description.at(1);
+        let new_txt1: DescriptionText = world.read_model((door.inst, key));
+        let new_txt2: DescriptionText = world.read_model((door.inst, key2));
 
-        assert_ne!(
-            inspectable.description[0],
-            new_inspectable.description[0],
-            "Effect should update description",
-        );
-        assert_eq!(
-            new_inspectable.description[1], new_value.at(1), "Effect should update description",
-        );
+        let (defTxt2, _defKey2) = new_value.at(1);
+
+        assert_ne!(old_txt.text, new_txt1.text.clone(), "Effect should update description");
+        assert_eq!(new_txt2.text.clone(), defTxt2.clone(), "Effect should update description");
         assert_eq!(result.is_ok(), true, "Effect should apply successfully");
     }
 }

--- a/packages/contracts/src/new_components/entity_trait.cairo
+++ b/packages/contracts/src/new_components/entity_trait.cairo
@@ -30,7 +30,7 @@ pub impl EntityImpl of EntityTrait {
         player.address = address;
         world.write_model(@player);
         let mut inspectable: Inspectable = Component::add_component(world, address.into());
-        let descr1 = DescriptionText { inst: address.into(), key: 0 , text: "Looks like a visitor"};
+        let descr1 = DescriptionText { inst: address.into(), key: 0, text: "Looks like a visitor" };
         world.write_model(@descr1);
         inspectable.description = array![0];
         world.write_model(@inspectable);

--- a/packages/contracts/src/new_components/entity_trait.cairo
+++ b/packages/contracts/src/new_components/entity_trait.cairo
@@ -3,7 +3,7 @@ use dojo::{world::{WorldStorage, IWorldDispatcherTrait}, model::ModelStorage};
 
 use lore::{
     models::{
-        index::{Entity, Inspectable, Player, ChildToParent, ParentToChildren},
+        index::{Entity, Inspectable, DescriptionText, Player, ChildToParent, ParentToChildren},
         components::Component, player::PlayerComponent, inspectable::InspectableComponent,
     },
     new_components::player_trait::PlayerImpl,
@@ -30,7 +30,9 @@ pub impl EntityImpl of EntityTrait {
         player.address = address;
         world.write_model(@player);
         let mut inspectable: Inspectable = Component::add_component(world, address.into());
-        inspectable.description = array!["Looks like a visitor"];
+        let descr1 = DescriptionText { inst: address.into(), key: 0 , text: "Looks like a visitor"};
+        world.write_model(@descr1);
+        inspectable.description = array![0];
         world.write_model(@inspectable);
         player.say(world, "You feel light, and shiny, in the head");
         player

--- a/packages/contracts/src/new_components/inspectable_trait.cairo
+++ b/packages/contracts/src/new_components/inspectable_trait.cairo
@@ -1,5 +1,5 @@
-use dojo::world::{WorldStorage, IWorldDispatcherTrait};
-use lore::{models::index::Inspectable, lib::random};
+use dojo::{model::ModelStorage, world::{WorldStorage, IWorldDispatcherTrait}};
+use lore::{models::index::{Inspectable, DescriptionText}, lib::random};
 
 
 #[generate_trait]
@@ -15,23 +15,28 @@ pub impl InspectableImpl of InspectableTrait {
         let rng: u32 = random::random_u16(world.dispatcher.uuid().try_into().unwrap())
             .try_into()
             .unwrap();
-        let description = self.description.at(rng % self.description.len()).clone();
-        description
+        let description_len: u32 = self.description.len().try_into().unwrap();
+        let entryRandom: u32 = (rng % description_len).try_into().unwrap();
+        let key: u32 = self.description.at(entryRandom).clone();
+        let descriptionText: DescriptionText = world.read_model((*self.inst, key));
+        descriptionText.text
     }
 
     fn get_first_description(self: @Inspectable, world: WorldStorage) -> ByteArray {
         if self.description.len() == 0 {
             return "";
         }
-        let description = self.description.at(0).clone();
-        description
+        let key: u32 = self.description.at(0).clone();
+        let descriptionText: DescriptionText = world.read_model((self.inst.clone(), key));
+        descriptionText.text
     }
 
-    fn get_specific_description(inspectabe: @Inspectable, index: u32) -> ByteArray {
-        if inspectabe.description.len() == 0 {
+    fn get_specific_description(inspectable: @Inspectable, index: u32, world: WorldStorage) -> ByteArray {
+        if inspectable.description.len() == 0 {
             return "";
         }
-        let description = inspectabe.description.at(index).clone();
-        description
+        let key: u32 = inspectable.description.at(index).clone();
+        let descriptionText: DescriptionText = world.read_model((inspectable.inst.clone(), key));
+        descriptionText.text
     }
 }

--- a/packages/contracts/src/new_components/inspectable_trait.cairo
+++ b/packages/contracts/src/new_components/inspectable_trait.cairo
@@ -31,7 +31,9 @@ pub impl InspectableImpl of InspectableTrait {
         descriptionText.text
     }
 
-    fn get_specific_description(inspectable: @Inspectable, index: u32, world: WorldStorage) -> ByteArray {
+    fn get_specific_description(
+        inspectable: @Inspectable, index: u32, world: WorldStorage,
+    ) -> ByteArray {
         if inspectable.description.len() == 0 {
             return "";
         }

--- a/packages/contracts/src/new_components/player_trait.cairo
+++ b/packages/contracts/src/new_components/player_trait.cairo
@@ -1,7 +1,7 @@
 use dojo::{world::WorldStorage, model::ModelStorage};
 use lore::{
     models::{
-        index::{Entity, Inspectable, Container, Player, PlayerStory}, components::Component,
+        index::{Entity, Inspectable, Container, Player, PlayerStory, StoryLine}, components::Component,
         inspectable::InspectableComponent, container::ContainerComponent,
     },
     new_components::{entity_trait::EntityImpl, inspectable_trait::InspectableImpl},
@@ -52,54 +52,47 @@ pub impl PlayerImpl of PlayerTrait {
 
     // TODO: improve name and better description
     fn say(mut self: @Player, mut world: WorldStorage, text: ByteArray) {
-        const MAX_LENGTH_LIMIT: usize = 2000;
-        let new_text_len = text.len();
-        let mut total_len = 0;
-
-        loop {
-            let playerStoryLoop: PlayerStory = world.read_model(*self.inst);
-            let mut storyLine = playerStoryLoop.story.clone();
-
-            total_len = 0;
-            for line in storyLine.clone() {
-                total_len += line.len();
-            };
-
-            if *self.use_debug {
-                self.clone().say(world, format!("Total length: {:?}", total_len));
-                self.clone().say(world, format!("New text length: {:?}", new_text_len));
-            }
-
-            if total_len + new_text_len <= MAX_LENGTH_LIMIT {
-                storyLine.append(text);
-                world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });
-                break;
-            }
-
-            if storyLine.len() == 0 {
-                // Edge case: nothing left to remove, but still too large
-                break;
-            }
-
-            let removed = storyLine.pop_front();
-            total_len -= removed.unwrap().len();
-            if *self.use_debug {
-                self.clone().say(world, format!("Total length after pop: {:?}", total_len));
-            }
-
-            world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });
-        }
+        // Read counter from player
+        let mut counter = *self.story_line;
+        // Increase counter
+        let increase: u64 = 1;
+        counter += increase;
+        // Create new story line
+        let mut story_line = StoryLine { inst: *self.inst, key: counter, line: text };
+        // Write story line to world
+        world.write_model(@story_line);
+        // Add story line to player story
+        let mut player_story: PlayerStory = world.read_model(*self.inst);
+        player_story.story.append(counter);
+        // update player_story.story
+        world.write_model(@player_story);
+        // try to store only the story variable but doesn't work
+        //world.write_member(Model::<PlayerStory>::ptr_from_keys(self.inst), selector!("story"), @player_story.story);
     }
 
 
     fn add_command_text(mut self: @Player, mut world: WorldStorage, text: ByteArray) {
-        let mut playerStory: PlayerStory = world.read_model(*self.inst);
-        let mut storyLine = playerStory.story.clone();
-        if (storyLine.len() > 10) {
-            let _ = storyLine.pop_front();
-        }
-        storyLine.append(format!("> {}", text));
-        world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });
+        // read counter from player
+        let mut counter = *self.story_line;
+        // increase counter
+        let increase: u64 = 1;
+        counter += increase;
+        // create new story line
+        let mut story_line = StoryLine { inst: *self.inst, key: counter, line: text };
+        // write story line to world
+        world.write_model(@story_line);
+        // add story line to player story
+        let mut player_story: PlayerStory = world.read_model(*self.inst);
+        player_story.story.append(counter);
+        // update player_story.story
+        world.write_model(@player_story);
+        // let mut playerStory: PlayerStory = world.read_model(*self.inst);
+        // let mut storyLine = playerStory.story.clone();
+        // if (storyLine.len() > 10) {
+        //     let _ = storyLine.pop_front();
+        // }
+        // storyLine.append(format!("> {}", text));
+        // world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });
     }
 
     fn get_room(self: @Player, world: @WorldStorage) -> Option<Entity> {

--- a/packages/contracts/src/new_components/player_trait.cairo
+++ b/packages/contracts/src/new_components/player_trait.cairo
@@ -1,8 +1,8 @@
 use dojo::{world::WorldStorage, model::ModelStorage};
 use lore::{
     models::{
-        index::{Entity, Inspectable, Container, Player, PlayerStory, StoryLine}, components::Component,
-        inspectable::InspectableComponent, container::ContainerComponent,
+        index::{Entity, Inspectable, Container, Player, PlayerStory, StoryLine},
+        components::Component, inspectable::InspectableComponent, container::ContainerComponent,
     },
     new_components::{entity_trait::EntityImpl, inspectable_trait::InspectableImpl},
     constants::errors::Error,
@@ -67,7 +67,8 @@ pub impl PlayerImpl of PlayerTrait {
         // update player_story.story
         world.write_model(@player_story);
         // try to store only the story variable but doesn't work
-        //world.write_member(Model::<PlayerStory>::ptr_from_keys(self.inst), selector!("story"), @player_story.story);
+    //world.write_member(Model::<PlayerStory>::ptr_from_keys(self.inst), selector!("story"),
+    //@player_story.story);
     }
 
 
@@ -87,12 +88,12 @@ pub impl PlayerImpl of PlayerTrait {
         // update player_story.story
         world.write_model(@player_story);
         // let mut playerStory: PlayerStory = world.read_model(*self.inst);
-        // let mut storyLine = playerStory.story.clone();
-        // if (storyLine.len() > 10) {
-        //     let _ = storyLine.pop_front();
-        // }
-        // storyLine.append(format!("> {}", text));
-        // world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });
+    // let mut storyLine = playerStory.story.clone();
+    // if (storyLine.len() > 10) {
+    //     let _ = storyLine.pop_front();
+    // }
+    // storyLine.append(format!("> {}", text));
+    // world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });
     }
 
     fn get_room(self: @Player, world: @WorldStorage) -> Option<Entity> {

--- a/packages/contracts/src/tests/helpers.cairo
+++ b/packages/contracts/src/tests/helpers.cairo
@@ -11,7 +11,7 @@ use lore::{
         index::{
             m_Dict, m_Entity, m_Area, m_Exit, m_Inspectable, m_InventoryItem, m_Container, m_Player,
             m_PlayerStory, m_ParentToChildren, m_ChildToParent, m_Trigger, m_TriggerIndex,
-            m_Condition, m_PropertyRegistry, m_Effect, m_Action, m_StoryLine,
+            m_Condition, m_PropertyRegistry, m_Effect, m_Action, m_StoryLine, m_DescriptionText,
         },
     },
     types::{command_type::IntoTokenTypeFelt252}, constants::{errors::{}},

--- a/packages/contracts/src/tests/helpers.cairo
+++ b/packages/contracts/src/tests/helpers.cairo
@@ -11,7 +11,7 @@ use lore::{
         index::{
             m_Dict, m_Entity, m_Area, m_Exit, m_Inspectable, m_InventoryItem, m_Container, m_Player,
             m_PlayerStory, m_ParentToChildren, m_ChildToParent, m_Trigger, m_TriggerIndex,
-            m_Condition, m_PropertyRegistry, m_Effect, m_Action,
+            m_Condition, m_PropertyRegistry, m_Effect, m_Action, m_StoryLine,
         },
     },
     types::{command_type::IntoTokenTypeFelt252}, constants::{errors::{}},
@@ -45,6 +45,7 @@ fn namespace_def() -> NamespaceDef {
             TestResource::Model(m_Dict::TEST_CLASS_HASH),
             TestResource::Model(m_Player::TEST_CLASS_HASH),
             TestResource::Model(m_PlayerStory::TEST_CLASS_HASH),
+            TestResource::Model(m_StoryLine::TEST_CLASS_HASH),
             TestResource::Model(m_Entity::TEST_CLASS_HASH),
             TestResource::Model(m_Inspectable::TEST_CLASS_HASH),
             TestResource::Model(m_Area::TEST_CLASS_HASH),

--- a/packages/contracts/src/tests/helpers.cairo
+++ b/packages/contracts/src/tests/helpers.cairo
@@ -48,6 +48,7 @@ fn namespace_def() -> NamespaceDef {
             TestResource::Model(m_StoryLine::TEST_CLASS_HASH),
             TestResource::Model(m_Entity::TEST_CLASS_HASH),
             TestResource::Model(m_Inspectable::TEST_CLASS_HASH),
+            TestResource::Model(m_DescriptionText::TEST_CLASS_HASH),
             TestResource::Model(m_Area::TEST_CLASS_HASH),
             TestResource::Model(m_Exit::TEST_CLASS_HASH),
             TestResource::Model(m_Container::TEST_CLASS_HASH),


### PR DESCRIPTION
# Description

Implemented new `Models` to improve text management across the components and storage. 

## Related issues

Closes #111 


## Introduced changes

The player story instead of having `story: Array<ByteArray>` now is `story: Array<CounterType>` where `CounterType is a `u64`. This array will store the `"key"` for the new model `StoryLine` that is composed by two keys (`inst` and `key`) and the variable `line` of type `ByteArray`. 

This approach will fix the error related to the `MAX_DATA_LENGHT` as Starknet limits the number of events emitted to 300 felts. The new implementation allows us to have more events as each felt can contain up to 3 `u64`'s

The `Inspectable` component now has an `Array<u32>` that will store the `keys` for the `DescriptionText` model that has two keys: `inst` (from the entity the inspectable is attached to) and `key` which is the unique id for the model that also serves as the index when mapping the inspectable actions to the text. This also helps to improve the setting of the description of objects when they change via the effect component

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
