### PR TITLE
chore: fix story output, inv item owner, client connection.

### DIFF
--- a/packages/client/src/data/command.data.ts
+++ b/packages/client/src/data/command.data.ts
@@ -8,7 +8,8 @@ import { APP_DATA } from "@/data/app.data";
 import { HELP_TEXTS, HELP_EXITS, HELP_INSPECT, HELP_CONTAINER, HELP_INVENTORY } from "@/data/help.data";
 import DojoStore from "@/lib/stores/dojo.store";
 import WalletStore from "../lib/stores/wallet.store";
-import { checkForPlayer } from "@/editor/data/editor.data";
+import { checkForPlayer, propertiesRegistered, } from "@/editor/data/editor.data";
+import {registerPropertyRegistry} from "../editor/publisher";
 
 /**
  * Context object passed to each terminal command handler
@@ -154,8 +155,24 @@ export const TERMINAL_SYSTEM_COMMANDS: {
 				useTypewriter: true,
 			});
 		}
+		// Check properties
+		const propertyRegistryFound = await propertiesRegistered();
+		if (!propertyRegistryFound) {
+			await registerPropertyRegistry();
+		}
 		// Call the check for player
+		addTerminalContent({
+			text: "You're getting ready...",
+			format: "hash",
+			useTypewriter: true,
+		});
 		await checkForPlayer();
+		// player created is done or done finding player
+		addTerminalContent({
+			text: "You're ready to continue your journey.",
+			format: "hash",
+			useTypewriter: true,
+		});
 	},
 	wallet: async () => {
 		if(!WalletStore().isConnected) {

--- a/packages/client/src/data/command.data.ts
+++ b/packages/client/src/data/command.data.ts
@@ -156,9 +156,14 @@ export const TERMINAL_SYSTEM_COMMANDS: {
 			});
 		}
 		// Check properties
-		const propertyRegistryFound = await propertiesRegistered();
+		await registerPropertyRegistry();
+
+		let propertyRegistryFound = await propertiesRegistered();
+		// Check properties
 		if (!propertyRegistryFound) {
-			await registerPropertyRegistry();
+			console.log("PropertyRegistry not found");
+		} else {
+			console.log("PropertyRegistry found");
 		}
 		// Call the check for player
 		addTerminalContent({

--- a/packages/client/src/editor/components/EditorHeader.tsx
+++ b/packages/client/src/editor/components/EditorHeader.tsx
@@ -5,6 +5,8 @@ import WalletStore, { useWalletStore } from "@/lib/stores/wallet.store";
 import { Config } from "../lib/config";
 import { publishConfigToContract } from "../publisher";
 import { Button } from "./ui/Button";
+import { registerPropertyRegistry } from "../publisher";
+import { propertiesRegistered } from "../data/editor.data";
 
 export const EditorHeader = () => {
 	const fileInputRef = useRef<HTMLInputElement>(null);
@@ -61,6 +63,13 @@ export const EditorHeader = () => {
 							className="btn btn-sm btn-warning"
 							onClick={async () => {
 								await WalletStore().connectController();
+								// Check properties
+								const propertyRegistryFound = await propertiesRegistered();
+								if (!propertyRegistryFound) {
+									await registerPropertyRegistry();
+								} else {
+									console.log("Property registry already found");
+								}
 							}}
 						>
 							Connect Controller

--- a/packages/client/src/editor/components/EditorHeader.tsx
+++ b/packages/client/src/editor/components/EditorHeader.tsx
@@ -63,12 +63,15 @@ export const EditorHeader = () => {
 							className="btn btn-sm btn-warning"
 							onClick={async () => {
 								await WalletStore().connectController();
+
+								await registerPropertyRegistry();
+
+								let propertyRegistryFound = await propertiesRegistered();
 								// Check properties
-								const propertyRegistryFound = await propertiesRegistered();
 								if (!propertyRegistryFound) {
-									await registerPropertyRegistry();
+									console.log("PropertyRegistry not found");
 								} else {
-									console.log("Property registry already found");
+									console.log("PropertyRegistry found");
 								}
 							}}
 						>

--- a/packages/client/src/editor/components/EntitySelector.tsx
+++ b/packages/client/src/editor/components/EntitySelector.tsx
@@ -1,0 +1,77 @@
+import { ChangeEvent, useMemo, useState } from "react";
+import { Select } from "./FormComponents";
+import { BigNumberish } from "starknet";
+
+interface EntitySelectorProps {
+  id: string;
+  value: string; 
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  dataPool: Map<BigNumberish, any>;
+  readOnly?: boolean;
+}
+
+export const EntitySelector = ({
+  id,
+  value,
+  onChange,
+  dataPool,
+  readOnly,
+}: EntitySelectorProps) => {
+  const [filter, setFilter] = useState("");
+
+  const handleUpdate = (val: string) => {
+    const syntheticEvent = {
+      target: {
+        id,
+        name: id,
+        value: val,
+        type: "string",
+      },
+    } as unknown as ChangeEvent<HTMLInputElement>;
+    onChange(syntheticEvent);
+  };
+
+  const entityOptions = useMemo(() => {
+    return Array.from(dataPool.entries())
+      .filter(([_, val]) => val.Entity?.name)
+      .map(([address, val]) => ({
+        label: val.Entity.name as string,
+        value: address,
+      }));
+  }, [dataPool]);
+
+  const filteredOptions = useMemo(() => {
+    if (!filter) return entityOptions;
+    const lower = filter.toLowerCase();
+    return entityOptions.filter((opt) =>
+      String(opt.label).toLowerCase().startsWith(lower)
+    );
+  }, [entityOptions, filter]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <input
+        type="text"
+        placeholder="Filter entities..."
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        className="border rounded p-1"
+        disabled={readOnly}
+      />
+
+      <Select
+        id={`entity-${id}`}
+        value={value}
+        onChange={(e) => handleUpdate(e.target.value)}
+        disabled={readOnly}
+        options={[
+          { value: "__placeholder__", label: "Select entity" },
+          ...filteredOptions.map((opt) => ({
+            value: opt.value.toString(),
+            label: String(opt.label),
+          })),
+        ]}
+      />
+    </div>
+  );
+};

--- a/packages/client/src/editor/components/inspectors/ConditionInspector.tsx
+++ b/packages/client/src/editor/components/inspectors/ConditionInspector.tsx
@@ -17,6 +17,8 @@ import { useInspector } from "./useInspector";
 import { stringCairoEnum } from "@/editor/lib/schemas";
 import { syncPropertyRegistry } from "../../data/editor.data";
 import { CollapsibleComponent } from "../CollapsibleComponent";
+import { EntitySelector } from "../EntitySelector";
+import { useEditorData } from "../../data/editor.data";
 
 // Individual Condition Item Component
 const ConditionItem = ({
@@ -56,6 +58,8 @@ const ConditionItem = ({
     label: name,
   }));
 
+  const { dataPool } = useEditorData();
+
   return (
     <CollapsibleComponent
       key={`${conditionObj.inst}-${conditionObj.key}`}
@@ -67,10 +71,11 @@ const ConditionItem = ({
           value={conditionObj.name}
           onChange={handleInputChange(idx)}
         />
-        <Input
+        <EntitySelector
           id="target"
           value={conditionObj.target.toString()}
           onChange={handleInputChange(idx)}
+          dataPool={dataPool}
         />
         <CairoEnumSelect
           id="component"

--- a/packages/client/src/editor/components/inspectors/EffectInspector.tsx
+++ b/packages/client/src/editor/components/inspectors/EffectInspector.tsx
@@ -16,6 +16,8 @@ import { stringCairoEnum } from "@/editor/lib/schemas";
 import { syncPropertyRegistry } from "../../data/editor.data";
 import { BigNumberish } from "starknet";
 import { CollapsibleComponent } from "../CollapsibleComponent";
+import { EntitySelector } from "../EntitySelector";
+import { useEditorData } from "../../data/editor.data";
 
 // Individual Effect Item Component
 const EffectItem = ({
@@ -54,6 +56,8 @@ const EffectItem = ({
     label: name,
   }));
 
+  const { dataPool } = useEditorData();
+
   return (
     <CollapsibleComponent
       key={`${effectObj.inst}-${effectObj.key}`}
@@ -66,10 +70,11 @@ const EffectItem = ({
           value={effectObj.name}
           onChange={handleInputChange(idx)}
         />
-        <Input
+        <EntitySelector
           id="target"
           value={effectObj.target.toString()}
           onChange={handleInputChange(idx)}
+          dataPool={dataPool}
         />
         <CairoEnumSelect
           id="effectType"

--- a/packages/client/src/editor/components/inspectors/EffectInspector.tsx
+++ b/packages/client/src/editor/components/inspectors/EffectInspector.tsx
@@ -103,6 +103,11 @@ const EffectItem = ({
           value={effectObj.n_value.toString()}
           onChange={handleInputChange(idx)}
         />
+        <Input
+          id="hex_value"
+          value={effectObj.hex_value.toString()}
+          onChange={handleInputChange(idx)}
+        />
       </Inspector>
     </CollapsibleComponent>
   );
@@ -139,6 +144,9 @@ export const EffectInspector: ComponentInspector<Effect> = ({
       },
       numeric_value: (e, updatedObject) => {
         updatedObject.n_value = e.target.value;
+      },
+      hex_value: (e, updatedObject) => {
+        updatedObject.hex_value = e.target.value;
       },
     },
   });

--- a/packages/client/src/editor/components/inspectors/PlayerInspector.tsx
+++ b/packages/client/src/editor/components/inspectors/PlayerInspector.tsx
@@ -28,10 +28,6 @@ export const PlayerInspector: ComponentInspector<Player> = ({
 				const event = e as ChangeEvent<HTMLInputElement>;
 				updatedObject.location = event.target.value as unknown as BigNumberish;
 			},
-			story_line: (e, updatedObject) => {
-				const event = e as ChangeEvent<HTMLInputElement>;
-				updatedObject.story_line = event.target.value;
-			},
 			use_debug: (e, updatedObject) => {
 				const event = e as ChangeEvent<HTMLInputElement>;
 				updatedObject.use_debug = event.target.checked;
@@ -59,12 +55,6 @@ export const PlayerInspector: ComponentInspector<Player> = ({
 				value={componentObject.location.toString()}
 				onChange={handleInputChange(undefined)}
 				//readOnly={true}
-			/>
-			<Input
-				id="story_line"
-				value={componentObject.story_line.toString()}
-				onChange={handleInputChange(undefined)}
-				// readOnly={true}
 			/>
 			<Toggle
 				id="use_debug"

--- a/packages/client/src/editor/components/inspectors/PlayerInspector.tsx
+++ b/packages/client/src/editor/components/inspectors/PlayerInspector.tsx
@@ -1,6 +1,7 @@
 import { type ChangeEvent} from "react";
 import {
 		type Player,
+		type PlayerStory,
 } from "@/lib/dojo_bindings/typescript/models.gen";
 import { Toggle, Input} from "../FormComponents";
 import type { ComponentInspector } from "./useInspector";
@@ -33,7 +34,7 @@ export const PlayerInspector: ComponentInspector<Player> = ({
 				updatedObject.use_debug = event.target.checked;
 			},
 		},
-	});
+	});	
 
 	if (!componentObject) return <div>Player not found</div>;
 
@@ -60,6 +61,35 @@ export const PlayerInspector: ComponentInspector<Player> = ({
 				id="use_debug"
 				value={componentObject.use_debug}
 				onChange={handleInputChange(undefined)}
+			/>
+		</Inspector>
+	);
+};
+
+export const PlayerStoryInspector: ComponentInspector<PlayerStory> = ({
+	componentObject,
+	...props
+}) => {
+	const { handleInputChange, Inspector } = useInspector<PlayerStory>({
+		componentObject,
+		...props,
+		inputHandlers: {
+			story_line: (e, updatedObject) => {
+				const event = e as ChangeEvent<HTMLInputElement>;
+				updatedObject.story_line = event.target.value;
+			},
+		},
+	});
+
+	if (!componentObject) return <div>PlayerStory not found</div>;
+
+	return (
+		<Inspector>
+			<Input
+				id="story_line"
+				value={componentObject.story_line.toString()}
+				onChange={handleInputChange(undefined)}
+				readOnly={true}
 			/>
 		</Inspector>
 	);

--- a/packages/client/src/editor/components/ui/Select.tsx
+++ b/packages/client/src/editor/components/ui/Select.tsx
@@ -86,9 +86,8 @@ const SelectContent = React.forwardRef<
 			<SelectScrollUpButton />
 			<SelectPrimitive.Viewport
 				className={cn(
-					"p-1",
-					position === "popper" &&
-						"h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+					"p-1 overflow-y-auto max-h-60", // max-h-60 = ~15rem, adjust as needed
+					"w-full min-w-[var(--radix-select-trigger-width)]"
 				)}
 			>
 				{children}
@@ -148,81 +147,81 @@ SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 export type SelectInputRef = { getValue: () => string | undefined };
 
 const SelectInput = React.forwardRef<
-	SelectInputRef,
-	React.HTMLAttributes<HTMLSelectElement> & {
-		value?: string;
-		defaultValue?: string;
-		disabled?: boolean;
-		className?: string;
-		onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
-		options: Array<{ value: string; label: string }> | OptionType[];
-	}
+  SelectInputRef,
+  React.HTMLAttributes<HTMLSelectElement> & {
+    value?: string;
+    defaultValue?: string;
+    disabled?: boolean;
+    className?: string;
+    onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+    options: Array<{ value: string; label: string }> | OptionType[];
+  }
 >(({ id, value, defaultValue, onChange, options, disabled }, ref) => {
-	const [internalValue, setInternalValue] = React.useState<string | undefined>(
-		value || (defaultValue as string | undefined),
-	);
-	const triggerRef = React.useRef<React.ElementRef<typeof SelectTrigger>>(null);
+  const [internalValue, setInternalValue] = React.useState<string | undefined>(
+    value || (defaultValue as string | undefined)
+  );
+  const triggerRef = React.useRef<React.ElementRef<typeof SelectTrigger>>(null);
 
-	React.useImperativeHandle(ref, () => ({
-		getValue: () => internalValue,
-	}));
+  React.useImperativeHandle(ref, () => ({
+    getValue: () => internalValue,
+  }));
 
-	const handleValueChange = (newValue: string) => {
-		setInternalValue(newValue);
+  const handleValueChange = (newValue: string) => {
+    setInternalValue(newValue);
 
-		// Create a synthetic event object that mimics a native select change event
-		const syntheticEvent = {
-			target: {
-				value: newValue,
-				name: id,
-				id: id,
-			},
-			currentTarget: {
-				value: newValue,
-				name: id,
-				id: id,
-			},
-			bubbles: true,
-			cancelable: true,
-			defaultPrevented: false,
-			preventDefault: () => {},
-			stopPropagation: () => {},
-			isPropagationStopped: () => false,
-			persist: () => {},
-			// Type info for TypeScript
-			nativeEvent: new Event("input"),
-		} as unknown as React.ChangeEvent<HTMLSelectElement>;
+    const syntheticEvent = {
+      target: { value: newValue, name: id, id: id },
+      currentTarget: { value: newValue, name: id, id: id },
+      bubbles: true,
+      cancelable: true,
+      defaultPrevented: false,
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      isPropagationStopped: () => false,
+      persist: () => {},
+      nativeEvent: new Event("input"),
+    } as unknown as React.ChangeEvent<HTMLSelectElement>;
 
-		onChange(syntheticEvent);
-	};
+    onChange(syntheticEvent);
+  };
 
-	// Update internal value when prop changes
-	React.useEffect(() => {
-		if (value !== undefined && value !== internalValue) {
-			setInternalValue(value);
-		}
-	}, [value, internalValue]);
-	return (
-		<Select
-			value={internalValue}
-			defaultValue={defaultValue || undefined}
-			disabled={disabled}
-			onValueChange={handleValueChange}
-		>
-			<SelectTrigger ref={triggerRef}>
-				<SelectValue />
-			</SelectTrigger>
-			<SelectContent>
-				<SelectGroup>
-					{options?.map((option) => (
-						<SelectItem key={option.value} value={option.value}>
-							{option.label}
-						</SelectItem>
-					))}
-				</SelectGroup>
-			</SelectContent>
-		</Select>
-	);
+  React.useEffect(() => {
+    if (value !== undefined && value !== internalValue) {
+      setInternalValue(value);
+    }
+  }, [value, internalValue]);
+
+  return (
+    <Select
+      value={internalValue}
+      defaultValue={defaultValue || undefined}
+      disabled={disabled}
+      onValueChange={handleValueChange}
+    >
+      <SelectTrigger ref={triggerRef}>
+        <SelectValue />
+      </SelectTrigger>
+
+      <SelectContent>
+        <SelectGroup>
+          {options?.map((option) => (
+            <SelectItem
+              key={option.value}
+              value={option.value}
+              ref={(el) => {
+                // scroll selected item into view for arrow keys
+                if (el && option.value === internalValue) {
+                  el.scrollIntoView({ block: "nearest" });
+                }
+              }}
+            >
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
 });
 
 export {

--- a/packages/client/src/editor/data/editor.data.ts
+++ b/packages/client/src/editor/data/editor.data.ts
@@ -35,7 +35,6 @@ import { tick } from "@/lib/utils/utils";
 import { InitDojo } from "@/lib/dojo";
 import { ToriiQueryBuilder } from "@dojoengine/sdk";
 import { type SchemaType } from "@lib/dojo_bindings/typescript/models.gen";
-
 import { getPlayerAddress } from "@/editor/lib/components";
 import { publishEntityCollection, publishConfigToContract } from "@/editor/publisher";
 
@@ -596,6 +595,8 @@ export const newPlayer = async (): Promise<EntityCollection | undefined> => {
 	const playerEntity = createPlayerEntity(spawnPoint.toString());
 	syncItem(playerEntity);
 	updateComponent(playerEntity.Entity.inst, "Entity", playerEntity.Entity);
+	updateComponent(playerEntity.Entity.inst, "Player", playerEntity.Player);
+	updateComponent(playerEntity.Entity.inst, "PlayerStory", playerEntity.PlayerStory);
 	await tick();
 
 	// parent will be the spawn point	
@@ -621,6 +622,7 @@ export const newPlayer = async (): Promise<EntityCollection | undefined> => {
 	updateComponent(playerEntity.Entity.inst, "DescriptionText", descriptionText.DescriptionText as any);
 	const reactable = createDefaultReactableComponent(playerEntity.Entity);
 	reactable.Reactable.description = [descriptionText.DescriptionText.key];
+	reactable.Reactable.new_entry = playerEntity.Entity.name;
 	updateComponent(playerEntity.Entity.inst, "Reactable", reactable.Reactable as any);
 	const container = createDefaultContainerComponent(playerEntity.Entity);
 	updateComponent(playerEntity.Entity.inst, "Container", container.Container as any);
@@ -721,29 +723,44 @@ export const getSpawnPoint = async (): Promise<BigNumberish> => {
  * @returns True if the player exists, false otherwise
  */
 export const getPlayer = async (account: string): Promise<boolean> => {
-	let playerFound = false;
-	try {
-		const { sdk } = await InitDojo();
-		const queryPlayer = () => {
-			const builder = new ToriiQueryBuilder<SchemaType>();
-			const query = builder.withCursor("").withLimit(1000).includeHashedKeys().withEntityModels(["lore-Player"]);
-			return query;
-		};
-		const result = await sdk.getEntities({ query: queryPlayer() });
-		result.getItems().forEach((item) => {
-			// Get models with type Player
-			const player = item.models?.lore?.Player;
-			// Check the player model inst matches the account
-			if (player?.inst === account) {
-				playerFound = true;
-			}
-		});
-		return playerFound;
-	} catch (error) {
-		console.error("Error fetching player from Torii:", error);
-		throw error;
-	}
-}
+  try {
+    const { sdk } = await InitDojo();
+    const query = new ToriiQueryBuilder<SchemaType>()
+      .withCursor("")
+      .withLimit(1000)
+      .includeHashedKeys()
+      .withEntityModels(["lore-Player"]);
+
+    const result = await sdk.getEntities({ query });
+
+    return result.getItems().some((item) => {
+      const player = item.models?.lore?.Player;
+      return player?.inst === account;
+    });
+  } catch (error) {
+    console.error("Error fetching player from Torii:", error);
+    throw error;
+  }
+};
+
+export const propertiesRegistered = async (): Promise<boolean> => {
+  try {
+    const { sdk } = await InitDojo();
+    const query = new ToriiQueryBuilder<SchemaType>()
+      .withCursor("")
+      .withLimit(1000)
+      .includeHashedKeys()
+      .withEntityModels(["lore-PropertyRegistry"]);
+
+    const result = await sdk.getEntities({ query });
+
+    // Just check if we got at least one PropertyRegistry model back
+    return result.getItems().some((item) => !!item.models?.lore?.PropertyRegistry);
+  } catch (error) {
+    console.error("Error fetching properties from Torii:", error);
+    throw error;
+  }
+};
 
 export let playerFound = false;
 export let playerExists = false;

--- a/packages/client/src/editor/data/editor.data.ts
+++ b/packages/client/src/editor/data/editor.data.ts
@@ -723,6 +723,13 @@ export const getSpawnPoint = async (): Promise<BigNumberish> => {
  * @returns True if the player exists, false otherwise
  */
 export const getPlayer = async (account: string): Promise<boolean> => {
+  console.log("getPlayer account using", account);
+
+  // Normalize Ethereum addresses (lowercase + remove extra leading zeros)
+  const normalizeAddress = (addr: string) =>
+    addr.replace(/^0x0+/, "0x").toLowerCase();
+  const normalizedAccount = normalizeAddress(account);
+
   try {
     const { sdk } = await InitDojo();
     const query = new ToriiQueryBuilder<SchemaType>()
@@ -735,7 +742,17 @@ export const getPlayer = async (account: string): Promise<boolean> => {
 
     return result.getItems().some((item) => {
       const player = item.models?.lore?.Player;
-      return player?.inst === account;
+      console.log("player", player);
+
+      const playerAddress = player?.address
+        ? normalizeAddress(player.address)
+        : null;
+      console.log("playerAddress", playerAddress);
+
+      if (playerAddress === normalizedAccount) {
+        return true;
+      }
+      return false;
     });
   } catch (error) {
     console.error("Error fetching player from Torii:", error);
@@ -743,7 +760,10 @@ export const getPlayer = async (account: string): Promise<boolean> => {
   }
 };
 
-export const propertiesRegistered = async (): Promise<boolean> => {
+export const propertiesRegistered = async (
+  maxRetries = 5,
+  delayMs = 2000
+): Promise<boolean> => {
   try {
     const { sdk } = await InitDojo();
     const query = new ToriiQueryBuilder<SchemaType>()
@@ -752,10 +772,29 @@ export const propertiesRegistered = async (): Promise<boolean> => {
       .includeHashedKeys()
       .withEntityModels(["lore-PropertyRegistry"]);
 
-    const result = await sdk.getEntities({ query });
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      const result = await sdk.getEntities({ query });
+      const items = result.getItems();
+      console.log(
+        `propertiesRegistered attempt ${attempt + 1}: found ${items.length} registries`,
+        items
+      );
 
-    // Just check if we got at least one PropertyRegistry model back
-    return result.getItems().some((item) => !!item.models?.lore?.PropertyRegistry);
+      if (items.length >= 6) {
+        console.log("✅ All 6 PropertyRegistry components are registered");
+        return true;
+      }
+
+      // Wait before retrying
+      if (attempt < maxRetries - 1) {
+        await new Promise((res) => setTimeout(res, delayMs));
+      }
+    }
+
+    console.warn(
+      `⚠️ Properties not fully registered after ${maxRetries} retries`
+    );
+    return false;
   } catch (error) {
     console.error("Error fetching properties from Torii:", error);
     throw error;
@@ -771,6 +810,7 @@ export let playerExists = false;
 export const checkForPlayer = async () => {
 	if (!playerExists) {
 		playerFound = await getPlayer(getPlayerAddress());
+		console.log("playerFound", playerFound);
 		if (playerFound) {
 			playerExists = true;
 		} else {

--- a/packages/client/src/editor/lib/components.ts
+++ b/packages/client/src/editor/lib/components.ts
@@ -21,7 +21,7 @@ import { DescriptionTextInspector } from "../components/inspectors/DescriptionIn
 import { createRandomName, randomKey, generateNumericUniqueId } from "../editor.utils";
 import type { EntityCollection, WithStringEnums } from "./types";
 import { LORE_CONFIG } from "@/lib/config";
-import WalletStore, { useWalletStore } from "@/lib/stores/wallet.store"
+import WalletStore from "@/lib/stores/wallet.store"
 import { BigNumberish } from "starknet";
 import randomName from "@scaleway/random-name";
 

--- a/packages/client/src/editor/lib/components.ts
+++ b/packages/client/src/editor/lib/components.ts
@@ -75,7 +75,6 @@ export const createPlayerComponent = (
 			inst: playerAddress,
 			is_player: true,
 			address: playerAddress,
-			story_line: 0,
 			location: 0,
 			use_debug: false,
 		},

--- a/packages/client/src/editor/lib/components.ts
+++ b/packages/client/src/editor/lib/components.ts
@@ -12,7 +12,7 @@ import { InventoryItemInspector } from "../components/inspectors/InventoryItemIn
 import { ReactableInspector } from "../components/inspectors/ReactableInspector";
 import type { ComponentInspector } from "../components/inspectors/useInspector";
 import { ContainerInspector } from "../components/inspectors/ContainerInspector";
-import { PlayerInspector } from "../components/inspectors/PlayerInspector";
+import { PlayerInspector, PlayerStoryInspector } from "../components/inspectors/PlayerInspector";
 import { TriggerInspector } from "../components/inspectors/TriggerInspector";
 import { ConditionInspector } from "../components/inspectors/ConditionInspector";
 import { EffectInspector } from "../components/inspectors/EffectInspector";
@@ -40,7 +40,7 @@ export const createDefaultEntity = (): WithStringEnums<
 
 export const createPlayerEntity = (
 	spawn_location?: BigNumberish
-): WithStringEnums<Pick<SchemaType["lore"], "Entity" | "Player">> => {
+): WithStringEnums<Pick<SchemaType["lore"], "Entity" | "Player" | "PlayerStory">> => {
 	const playerAddress = getPlayerAddress();
 	const playerName = getPlayerName();
 	return {
@@ -50,15 +50,20 @@ export const createPlayerEntity = (
 			inst: playerAddress,
 			is_entity: true,
 			name: playerName,
-			alt_names: [],
+			alt_names: [playerName, "me", "myself"],
 		},
 		Player: {
 			...schema.lore.Player,
 			inst: playerAddress,
 			is_player: true,
 			address: playerAddress,
-			location: spawn_location?.toString() || 0,
+			location: spawn_location!.toString() || 0,
 			use_debug: false,
+		},
+		PlayerStory: {
+			...schema.lore.PlayerStory,
+			inst: playerAddress,
+			story_line: 0,
 		},
 	};
 };
@@ -78,6 +83,19 @@ export const createPlayerComponent = (
 			location: 0,
 			use_debug: false,
 		},
+	};
+};
+
+export const createPlayerStoryComponent = (
+	_entity: Entity,
+): WithStringEnums<Pick<SchemaType["lore"], "PlayerStory">> => {
+	const address = LORE_CONFIG.wallet.address;
+	return { 
+		PlayerStory: {
+			...schema.lore.PlayerStory,
+			inst: address,
+			story_line: 0,
+		}
 	};
 };
 
@@ -293,6 +311,12 @@ export const componentData: {
 		inspector: PlayerInspector,
 		icon: "👤",
 		creator: createPlayerComponent,
+		},
+	PlayerStory: {
+		order: 1,
+		inspector: PlayerStoryInspector,
+		icon: "👤",
+		creator: createPlayerStoryComponent,
 	},
 	Area: {
 		order: 2,
@@ -375,4 +399,4 @@ export const getPlayerName = (): string => {
 		}
 	}
 	return randomName();
-}
+};

--- a/packages/client/src/editor/publisher.ts
+++ b/packages/client/src/editor/publisher.ts
@@ -159,7 +159,6 @@ const publishPlayer = async (player: Player) => {
 		player.is_player ?? true,
 		player.address ? num.toBigInt(player.address.toString()) : num.toBigInt(getPlayerAddress().toString()),
 		player.location ? num.toBigInt(player.location.toString()) : num.toBigInt("0"),
-		player.story_line ? num.toBigInt(player.story_line.toString()) : num.toBigInt("0"),
 		player.use_debug ?? false,
 	];
 	await dispatchDesignerCall("create_player", [playerData]);

--- a/packages/client/src/editor/publisher.ts
+++ b/packages/client/src/editor/publisher.ts
@@ -486,13 +486,9 @@ export const registerPropertyRegistry = async () => {
 	}
 };
 
-let alreadyDone = false;
 const publishRegisterPropertyRegistry = async () => {
-	if (alreadyDone == false) {
 		let done = true;
 		await dispatchDesignerCall("register_property_registry", [done]);
-		alreadyDone = true;
-	}
 };
 
 /**

--- a/packages/client/src/editor/publisher.ts
+++ b/packages/client/src/editor/publisher.ts
@@ -328,6 +328,7 @@ const publishEffect = async (
 				num.toBigInt(i.toString() ?? 0),
 			]),
 			num.toBigInt(effect.n_value.toString() ?? 0),
+			num.toBigInt(effect.hex_value.toString() ?? num.toBigInt("0")),
 		];
 		await dispatchDesignerCall("create_effect", [preparedEffect]);
 	}

--- a/packages/client/src/editor/publisher.ts
+++ b/packages/client/src/editor/publisher.ts
@@ -486,7 +486,7 @@ export const registerPropertyRegistry = async () => {
 	}
 };
 
-export let alreadyDone = false;
+let alreadyDone = false;
 const publishRegisterPropertyRegistry = async () => {
 	if (alreadyDone == false) {
 		let done = true;

--- a/packages/client/src/lib/dojo.ts
+++ b/packages/client/src/lib/dojo.ts
@@ -9,7 +9,6 @@ import {
 	type SchemaType,
 	schema,
 } from "@lib/dojo_bindings/typescript/models.gen";
-import {registerPropertyRegistry, alreadyDone} from "../editor/publisher";
 
 /**
  * ## Initializes the Dojo SDK and configuration
@@ -79,6 +78,6 @@ export const InitDojo = async () => {
 	};
 
 	console.log( {sdk, dojoConfig, provider, query, sub})
-	
+
 	return { sdk, dojoConfig, provider, query, sub };
 };

--- a/packages/client/src/lib/dojo.ts
+++ b/packages/client/src/lib/dojo.ts
@@ -79,13 +79,6 @@ export const InitDojo = async () => {
 	};
 
 	console.log( {sdk, dojoConfig, provider, query, sub})
-
-	/**
-	 * Register property registry
-	 */
-	if (alreadyDone == false) {
-		await registerPropertyRegistry();
-	}
-
+	
 	return { sdk, dojoConfig, provider, query, sub };
 };

--- a/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
@@ -2,6 +2,13 @@ import type { SchemaType as ISchemaType } from "@dojoengine/sdk";
 
 import { CairoCustomEnum, type BigNumberish } from 'starknet';
 
+// Type definition for `lore::lib::relations::ChildToParent` struct
+export interface ChildToParent {
+	inst: BigNumberish;
+	is_child: boolean;
+	parent: BigNumberish;
+}
+
 // Type definition for `lore::models::index::Action` struct
 export interface Action {
 	inst: BigNumberish;
@@ -24,13 +31,6 @@ export interface Area {
 	inst: BigNumberish;
 	is_area: boolean;
 	is_spawn_point: boolean;
-}
-
-// Type definition for `lore::models::index::ChildToParent` struct
-export interface ChildToParent {
-	inst: BigNumberish;
-	is_child: boolean;
-	parent: BigNumberish;
 }
 
 // Type definition for `lore::models::index::ComponentVariable` struct
@@ -93,6 +93,7 @@ export interface Effect {
 	property: string;
 	value: Array<[string, BigNumberish]>;
 	n_value: BigNumberish;
+	hex_value: BigNumberish;
 }
 
 // Type definition for `lore::models::index::Entity` struct
@@ -377,9 +378,9 @@ export type PropertyTypeEnum = CairoCustomEnum;
 
 export interface SchemaType extends ISchemaType {
 	lore: {
+		ChildToParent: ChildToParent,
 		Action: Action,
 		Area: Area,
-		ChildToParent: ChildToParent,
 		ComponentVariable: ComponentVariable,
 		Condition: Condition,
 		Container: Container,
@@ -406,6 +407,11 @@ export interface SchemaType extends ISchemaType {
 }
 export const schema: SchemaType = {
 	lore: {
+		ChildToParent: {
+			inst: 0,
+			is_child: false,
+			parent: 0,
+		},
 		Action: {
 			inst: 0,
 			key: 0,
@@ -425,11 +431,6 @@ export const schema: SchemaType = {
 			inst: 0,
 			is_area: false,
 			is_spawn_point: false,
-		},
-		ChildToParent: {
-			inst: 0,
-			is_child: false,
-			parent: 0,
 		},
 		ComponentVariable: {
 			inst: 0,
@@ -542,6 +543,7 @@ export const schema: SchemaType = {
 		property: "",
 			value: [["", 0]],
 			n_value: 0,
+			hex_value: 0,
 		},
 		Entity: {
 			inst: 0,
@@ -727,9 +729,9 @@ export const schema: SchemaType = {
 	},
 };
 export enum ModelsMapping {
+	ChildToParent = 'lore-ChildToParent',
 	Action = 'lore-Action',
 	Area = 'lore-Area',
-	ChildToParent = 'lore-ChildToParent',
 	ComponentVariable = 'lore-ComponentVariable',
 	Condition = 'lore-Condition',
 	Container = 'lore-Container',

--- a/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
@@ -141,14 +141,13 @@ export interface Player {
 	is_player: boolean;
 	address: string;
 	location: BigNumberish;
-	story_line: BigNumberish;
 	use_debug: boolean;
 }
 
 // Type definition for `lore::models::index::PlayerStory` struct
 export interface PlayerStory {
 	inst: BigNumberish;
-	story: Array<BigNumberish>;
+	story_line: BigNumberish;
 }
 
 // Type definition for `lore::models::index::PropertyRegistry` struct
@@ -597,12 +596,11 @@ export const schema: SchemaType = {
 			is_player: false,
 			address: "",
 			location: 0,
-			story_line: 0,
 			use_debug: false,
 		},
 		PlayerStory: {
 			inst: 0,
-			story: [0],
+			story_line: 0,
 		},
 		PropertyRegistry: {
 		component_type: new CairoCustomEnum({ 

--- a/packages/client/src/lib/stores/dojo.store.ts
+++ b/packages/client/src/lib/stores/dojo.store.ts
@@ -66,34 +66,10 @@ const setStatus = (status: DojoStatus) => set({ status });
 const setOutputter = async (playerStory: PlayerStory | undefined) => {
 	if (!playerStory) return;
 
-	const previousStory = get().playerStory?.story || [];
-	const newStory = playerStory.story;
-	const isNewText = previousStory.length > 0;
-
 	const lastKeyUsed = get().lastKeyUsed ?? -1;
-
 	const printed = get().printedKeys;
 
-	// Get only new keys (greater than last used), sorted ascending, and remove from printed set
-	const rawNewKeys = newStory
-		.map(Number)
-		.filter((key) => key > lastKeyUsed && !printed.has(key));
-
-	if (rawNewKeys.length === 0) return;
-
-	const newKeys = [...new Set(rawNewKeys)].sort((a, b) => a - b);
-	set({ lastKeyUsed: Number(newKeys[newKeys.length - 1]) });
-	// Store last key used in local storage
-	localStorage.setItem("lastKeyUsed", String(newKeys[newKeys.length - 1]));
-	// Add new keys to printed set and persist
-	for (const key of newKeys) {
-		printed.add(Number(key));
-	}
-	// Add printed keys to local storage
-	set({ printedKeys: printed });
-	localStorage.setItem("printedKeys", JSON.stringify(Array.from(printed)));
-
-	// Fetch StoryLine models directly from Torii
+	// Fetch all StoryLines for this player
 	const allStoryLines: StoryLine[] = [];
 	try {
 		const { sdk } = await InitDojo();
@@ -123,90 +99,76 @@ const setOutputter = async (playerStory: PlayerStory | undefined) => {
 		});
 	} catch (error) {
 		console.error("Error fetching StoryLine models from Torii:", error);
-		throw error;
+		return;
 	}
 
-	// Build a map of key => line
-	const storyLineMap = new Map<string, string>();
-	for (const s of allStoryLines) {
-		const keyStr = String(s.key);
-		if (!storyLineMap.has(keyStr)) {
-			storyLineMap.set(keyStr, s.line);
+	// Filter new keys and normalize to number
+	const newLines = allStoryLines
+		.filter((s) => Number(s.key) > lastKeyUsed && !printed.has(Number(s.key)))
+		.sort((a, b) => Number(a.key) - Number(b.key));
+
+	if (newLines.length === 0) return;
+
+	// Update lastKeyUsed and printedKeys
+	const maxKey = Number(newLines[newLines.length - 1].key);
+	set({ lastKeyUsed: maxKey });
+	localStorage.setItem("lastKeyUsed", String(maxKey));
+
+	for (const s of newLines) printed.add(Number(s.key));
+	set({ printedKeys: printed });
+	localStorage.setItem("printedKeys", JSON.stringify(Array.from(printed)));
+
+	// Add lines to terminal
+	for (const s of newLines) {
+		const trimmed = decodeDojoText(s.line.trim());
+		const lines = processWhitespaceTags(trimmed);
+		for (const l of lines) {
+			const sys = l.startsWith("+sys+");
+			const formatted = l.replaceAll("+sys+", "");
+			addTerminalContent({
+				text: formatted,
+				format: sys ? "hash" : l.startsWith("> ") ? "input" : "out",
+				useTypewriter: true,
+			});
 		}
 	}
 
-	// Map new keys to lines
-	const storyLines: string[] = [];
-	for (const key of newKeys) {
-		const line = storyLineMap.get(String(key));
-		if (line) {
-			storyLines.push(line);
-		}
-	}
-
-	if (storyLines.length === 0) return;
-
-	// Remove prompt line if duplicated
-	if (isNewText && storyLines[0]?.startsWith("> ")) {
-		storyLines.shift();
-	}
-
-	const newText = storyLines.join("\n");
-	//console.log("[STORY]:", newText);
-
-	const trimmedNewText = decodeDojoText(newText.trim());
-	const lines = processWhitespaceTags(trimmedNewText);
-
-	set({
-		lastProcessedText: trimmedNewText,
-		playerStory,
-	});
-
-	// Add new lines to terminal
-	for (const line of lines) {
-		const sys = line.startsWith("+sys+");
-		const formatted = line.replaceAll("+sys+", "");
-
-		addTerminalContent({
-			text: formatted,
-			format: sys ? "hash" : line.startsWith("> ") ? "input" : "out",
-			useTypewriter: true,
-		});
-	}
+	set({ lastProcessedText: newLines.map((s) => s.line).join("\n"), playerStory });
 };
 
-const onPlayerStory = (playerStory: Partial<PlayerStory>) => {
+const onPlayerStory = (playerStory: PlayerStory) => {
 	const address = !LORE_CONFIG.useController
 		? LORE_CONFIG.wallet.address
 		: WalletStore().controller?.account?.address;
+	// console.log("[DEBUG] address", address);
+	// console.log("[DEBUG] playerStory1", playerStory);
 	const normalizedPlayerId = num.cleanHex(String(playerStory.inst));
 	const normalizedAddress = num.cleanHex(String(address));
+	// console.log("[DEBUG] normalizedPlayerId", normalizedPlayerId);
+	// console.log("[DEBUG] normalizedAddress", normalizedAddress);
 	if (normalizedPlayerId === normalizedAddress) {
+		// console.log("[DEBUG] onPlayerStory", playerStory);
 		setOutputter(playerStory as PlayerStory);
 		return;
 	}
 };
 
 const onReponseData = (
-	responseData: ParsedEntity<SchemaType>["models"]["lore"],
+    responseData: ParsedEntity<SchemaType>["models"]["lore"],
 ) => {
-	// console.log("[DOJO] onReponseData", responseData);
-	if (responseData.PlayerStory && responseData.PlayerStory.story) {
-		if (get().originalStoryLength === 0) {
-			// Set original length AFTER handling the first story
-			onPlayerStory(responseData.PlayerStory);
-			set({ originalStoryLength: responseData.PlayerStory.story.length });
-		} else {
-			const slicedStory = {
-				...responseData.PlayerStory,
-				story: responseData.PlayerStory.story.slice(get().originalStoryLength),
-			};
-			onPlayerStory(slicedStory);
-		}
-	}
-	EditorData().dojoSync(responseData as EntityCollection, {
-		verbose: true,
-	});
+    // console.log("[DEBUG] onReponseData", responseData);
+
+    // Check if there’s a PlayerStory update
+    if (responseData.PlayerStory && responseData.PlayerStory.story_line !== undefined) {
+        const playerStory = responseData.PlayerStory as PlayerStory;
+        // console.log("[DEBUG] RD playerStory received", playerStory);
+
+        // Pass directly to setOutputter via onPlayerStory
+        onPlayerStory(playerStory);
+    }
+
+    // Always sync EditorData for lore entities
+    EditorData().dojoSync(responseData as EntityCollection, { verbose: true });
 };
 
 // Resets the local storage of the processed text and keys

--- a/packages/client/src/lib/stores/wallet.store.ts
+++ b/packages/client/src/lib/stores/wallet.store.ts
@@ -71,10 +71,6 @@ const setupController = async () => {
 					description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
 				},
 				{
-					entrypoint: "create_description_text",
-					description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
-				},
-				{
 					entrypoint: "create_area",
 					description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
 				},
@@ -202,6 +198,132 @@ const setupController = async () => {
 						{
 							entrypoint: "transfer_from", // The actual method name
 							description: "Transfer a TOT Token",
+						},
+					],
+				},
+				[LORE_CONFIG.manifest.designer.address]: {
+					name: APP_EDITOR_DATA.title, // Optional, can be added if you want a name
+					description: `Aprove submitting transactions to ${APP_EDITOR_DATA.title}`,
+					methods: [
+						{
+							entrypoint: "register_property_registry",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_player",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_entity",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_reactable",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_description_text",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_area",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_exit",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_inventory_item",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_container",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_parent",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_condition",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_effect",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_action",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_trigger",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "create_child",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_player",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_entity",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_reactable",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_description_text",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_description_text",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_area",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_exit",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_condition",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_inventory_item",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_trigger",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_effect",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_action",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_container",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_parent",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
+						},
+						{
+							entrypoint: "delete_child",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title}`,
 						},
 					],
 				},

--- a/packages/contracts/Scarb.toml
+++ b/packages/contracts/Scarb.toml
@@ -14,9 +14,10 @@ migrate = "sozo build && sozo migrate apply"
 [dependencies]
 dojo = { git = "https://github.com/dojoengine/dojo", tag = "v1.6.1" }
 origami_random = { git = "https://github.com/dojoengine/origami", tag = "v1.6.1" }
+# dojo_macros = { git = "https://github.com/dojoengine/dojo", tag = "v1.7.0-alpha.2" }
 # not used right now but initialised in dojo_init when used for deli interop
 # planetary_interface = { path = "/Users/tims/DATA/BB/dojo/planetary/dojo/planetary_interface" }
-# starknet = "2.8.4"
+# starknet = "2.12.1"
 
 [dev-dependencies]
 cairo_test = "=2.10.1"

--- a/packages/contracts/dojo_dev.toml
+++ b/packages/contracts/dojo_dev.toml
@@ -12,7 +12,8 @@ slot_name = "lore-v3"
 
 account_address = "0x6677fe62ee39c7b07401f754138502bab7fac99d2d3c5d37df7d1c6fab10819"
 private_key = "0x3e3979c1ed728490308054fe357a9f49cf67f80f9721f44cc57235129e090f4"
-world_address = "0x545eeac1e37165b8aebc1af423f823b5dd941d82f1d16208eb4a26f562e3aa6"
+world_address = "0x545eeac1e37165b8aebc1af423f823b5dd941d82f1d16208eb4a26f562e3aa6" # 1.6.1
+# world_address = "0x3e85f67a683208a20768683934c1570b7e6a4a5eb99afd06f70fb935f2454ae" # 1.7.0-alpha.2
 
 [writers]
 "lore" = ["lore-prompt", "lore-designer"]

--- a/packages/contracts/dojo_slot.toml
+++ b/packages/contracts/dojo_slot.toml
@@ -12,7 +12,8 @@ slot_name = "lore-v3"
 
 account_address = "0x6677fe62ee39c7b07401f754138502bab7fac99d2d3c5d37df7d1c6fab10819"
 private_key = "0x3e3979c1ed728490308054fe357a9f49cf67f80f9721f44cc57235129e090f4"
-world_address = "0x545eeac1e37165b8aebc1af423f823b5dd941d82f1d16208eb4a26f562e3aa6"
+world_address = "0x545eeac1e37165b8aebc1af423f823b5dd941d82f1d16208eb4a26f562e3aa6" # 1.6.1
+# world_address = "0x3e85f67a683208a20768683934c1570b7e6a4a5eb99afd06f70fb935f2454ae" # 1.7.0-alpha.2
 
 [writers]
 "lore" = ["lore-prompt", "lore-designer"]

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -1328,8 +1328,8 @@
   },
   "contracts": [
     {
-      "address": "0x7ce3aa65a3760ceacacfa93532f48c5d53078845fdb1051c91c875415a2a0ec",
-      "class_hash": "0x4a0c48f3146e72447d0fcf42516025b6526b71ab86f56875b575801e93251e1",
+      "address": "0x318730a49a71d0060379a7f81f4ade9085c74815236608e3c7d2dc8a3639c73",
+      "class_hash": "0xafb5718d176cdb950153d719054134745b218c240a0d1fcf9d1265326f808a",
       "abi": [
         {
           "type": "impl",
@@ -1419,10 +1419,6 @@
             {
               "name": "location",
               "type": "core::felt252"
-            },
-            {
-              "name": "story_line",
-              "type": "core::integer::u32"
             },
             {
               "name": "use_debug",
@@ -2696,8 +2692,8 @@
       ]
     },
     {
-      "address": "0x5672d62652690442ed88ced6b603f64d75b410fee09ab069e4ce5111bc3f907",
-      "class_hash": "0x5b27a51e2d00b00cdec6b791b0be1236300b62a002603ec503e46a3b6b606d4",
+      "address": "0x7218861e9f9b6d9dee834047a5ab126c326ba20fe79c7f548510d810798bfcd",
+      "class_hash": "0x5d217932a551fafa525f134b0970bb811fc7c6e3dd653dff1be2874f48db881",
       "abi": [
         {
           "type": "impl",
@@ -2978,13 +2974,13 @@
     },
     {
       "members": [],
-      "class_hash": "0x76b859ea6ae4fb59883549783103b1e56330e3fad2d4e2776e57e1d5500f490",
+      "class_hash": "0x5a83fa359a52c2b2e1a3a0a6ba49e34a4d4fc7669e641ef890f474ff5e4aaa6",
       "tag": "lore-Player",
       "selector": "0x3a26dabe7dd21bfc4f1549b782ffa326118e6134af2180128a0cfb2456cd8f0"
     },
     {
       "members": [],
-      "class_hash": "0x789245bdefe86c42501e150ca819191c75430eb9951bdf87c41dc84e12668e8",
+      "class_hash": "0x72da72753eb97a49f8f7ce6a3668960b7dcaf41e6652308f88da5aa070244a8",
       "tag": "lore-PlayerStory",
       "selector": "0x6e53919f65474ab8e20728f119321dd5b0beffcaf7677f67afbb2f82f05aae0"
     },

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -2692,8 +2692,8 @@
       ]
     },
     {
-      "address": "0x7218861e9f9b6d9dee834047a5ab126c326ba20fe79c7f548510d810798bfcd",
-      "class_hash": "0x27321bed3f684c10855567e302456db5d52e827f56c742c895244fb92fab2cc",
+      "address": "0x1bc7a4c9a90a440e6b0fdbbedd4d4f64468cde3da9200d17990c476c680e5a9",
+      "class_hash": "0x6891efd9a8a20fdc1fff18f09baa343b6e9171398a5c36240666ec52a1f0c9d",
       "abi": [
         {
           "type": "impl",

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -1328,8 +1328,8 @@
   },
   "contracts": [
     {
-      "address": "0x67831517a668320d44e6911014920e21bed6ed709096a4b7d8c0987caa58385",
-      "class_hash": "0x37a443f0581dd061742aee5e0f7364b81343dd68075a675fd1a76cc958c8280",
+      "address": "0x7ce3aa65a3760ceacacfa93532f48c5d53078845fdb1051c91c875415a2a0ec",
+      "class_hash": "0x4a0c48f3146e72447d0fcf42516025b6526b71ab86f56875b575801e93251e1",
       "abi": [
         {
           "type": "impl",
@@ -2089,6 +2089,10 @@
             {
               "name": "n_value",
               "type": "core::integer::u32"
+            },
+            {
+              "name": "hex_value",
+              "type": "core::felt252"
             }
           ]
         },
@@ -2692,8 +2696,8 @@
       ]
     },
     {
-      "address": "0x397a41c41bff02a4c11593665473c712ef5377a614a8c37da6d7628fc9288c0",
-      "class_hash": "0xe740d8c663c2b59854744d6fa8c9dde0920faa320f3755c2167b7ee8b9e1a7",
+      "address": "0x5672d62652690442ed88ced6b603f64d75b410fee09ab069e4ce5111bc3f907",
+      "class_hash": "0x5b27a51e2d00b00cdec6b791b0be1236300b62a002603ec503e46a3b6b606d4",
       "abi": [
         {
           "type": "impl",
@@ -2908,7 +2912,7 @@
     },
     {
       "members": [],
-      "class_hash": "0x5dd0a40f39f0ba1c787d5b7aa2adddc3fe88a71f1aa5071ba3ec2fc8407b35c",
+      "class_hash": "0x2bf734f4b3cf7681a839fc565677becf877524a5a1e04bf16a96de6da3b1931",
       "tag": "lore-ChildToParent",
       "selector": "0x6c2a358df76ae2ca942ea3cc2f59ade04e5f5ba87ee162b41a10ad5a5755287"
     },
@@ -2944,7 +2948,7 @@
     },
     {
       "members": [],
-      "class_hash": "0x59e1bbcbd5d85e34401ed83edf59314ac9cfb278ab332655a6ca791fa96ca9c",
+      "class_hash": "0x52d571c0e79fcd1a4e46317029821242832ee45a738182e4a5a94cde5ec0d22",
       "tag": "lore-Effect",
       "selector": "0x753486095174e7622f7115f0ba45a0401d64fad9adb37d3cd8e115a0b86a5f9"
     },

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -2693,7 +2693,7 @@
     },
     {
       "address": "0x7218861e9f9b6d9dee834047a5ab126c326ba20fe79c7f548510d810798bfcd",
-      "class_hash": "0x5d217932a551fafa525f134b0970bb811fc7c6e3dd653dff1be2874f48db881",
+      "class_hash": "0x27321bed3f684c10855567e302456db5d52e827f56c742c895244fb92fab2cc",
       "abi": [
         {
           "type": "impl",

--- a/packages/contracts/src/lib/dictionary.cairo
+++ b/packages/contracts/src/lib/dictionary.cairo
@@ -87,6 +87,7 @@ pub fn init_dictionary(world: WorldStorage) {
     add_to_dictionary(world, "play", TokenType::Verb, 40).unwrap();
     add_to_dictionary(world, "validate", TokenType::Verb, 41).unwrap();
     add_to_dictionary(world, "approach", TokenType::Verb, 42).unwrap();
+    add_to_dictionary(world, "praise", TokenType::Verb, 43).unwrap();
 
     // directions
     add_to_dictionary(world, "north", TokenType::Direction, 1).unwrap();

--- a/packages/contracts/src/lib/variable_property.cairo
+++ b/packages/contracts/src/lib/variable_property.cairo
@@ -6,9 +6,8 @@ use lore::{
         inventoryItem::InventoryItemComponent, container::ContainerComponent,
         player::PlayerComponent,
     },
-    types::{property_type::PropertyAccess, component_type::ComponentType, action_type::EffectType},
+    types::{property_type::PropertyAccess, component_type::ComponentType},
     lib::{utils::ByteArrayTraitExt, variable_property_helper::VariablePropertyHelperTrait},
-    constants::errors::Error,
 };
 
 
@@ -95,90 +94,90 @@ pub impl VariablePropertyImp of VariablePropertyTrait {
         return (property_value, access);
     }
 
-    fn set_property(
-        mut world: @WorldStorage,
-        key: @felt252,
-        effect_type: @EffectType,
-        property_name: @ByteArray,
-        new_value: @Array<(ByteArray, u32)>,
-        num_value: @u32,
-        component_type: ComponentType,
-    ) -> Result<(), Error> {
-        let property_registry: PropertyRegistry = world.read_model((component_type));
-        let mut success: bool = false;
-        let mut result: Result::<(), Error> = Result::Err((Error::EffectFailed));
-        match component_type.clone() {
-            ComponentType::Area => {
-                let component: Area = world.read_model(*key);
-                let prop_text = property_name.clone();
-                let (result_p, success_p) = VariablePropertyHelperTrait::set_area_property(
-                    component, *world, @prop_text, @property_registry, new_value,
-                );
-                result = result_p;
-                success = success_p;
-            },
-            ComponentType::Exit => {
-                let component: Exit = world.read_model(*key);
-                let prop_text = property_name.clone();
-                let (result_p, success_p) = VariablePropertyHelperTrait::set_exit_property(
-                    component, *world, @prop_text, @property_registry, new_value,
-                );
-                result = result_p;
-                success = success_p;
-            },
-            ComponentType::Reactable => {
-                let component: Reactable = world.read_model(*key);
-                let prop_text = property_name.clone();
-                let (result_p, success_p) = VariablePropertyHelperTrait::set_reactable_property(
-                    component, *world, @prop_text, @property_registry, new_value,
-                );
-                result = result_p;
-                success = success_p;
-            },
-            ComponentType::InventoryItem => {
-                let component: InventoryItem = world.read_model(*key);
-                let prop_text = property_name.clone();
-                let (result_p, success_p) =
-                    VariablePropertyHelperTrait::set_inventory_item_property(
-                    component,
-                    *world,
-                    @prop_text,
-                    effect_type,
-                    @property_registry,
-                    new_value,
-                    num_value,
-                );
-                result = result_p;
-                success = success_p;
-            },
-            ComponentType::Container => {
-                let component: Container = world.read_model(*key);
-                let prop_text = property_name.clone();
-                let (result_p, success_p) = VariablePropertyHelperTrait::set_container_property(
-                    component,
-                    *world,
-                    @prop_text,
-                    effect_type,
-                    @property_registry,
-                    new_value,
-                    num_value,
-                );
-                result = result_p;
-                success = success_p;
-            },
-            ComponentType::Player => {
-                let component: Player = world.read_model(*key);
-                let prop_text = property_name.clone();
-                let (result_p, success_p) = VariablePropertyHelperTrait::set_player_property(
-                    component, *world, @prop_text, @property_registry, new_value,
-                );
-                result = result_p;
-                success = success_p;
-            },
-            _ => { // Do nothing
-            },
-        }
-        return result;
-    }
+    // fn set_property(
+    //     mut world: @WorldStorage,
+    //     key: @felt252,
+    //     effect_type: @EffectType,
+    //     property_name: @ByteArray,
+    //     new_value: @Array<(ByteArray, u32)>,
+    //     num_value: @u32,
+    //     component_type: ComponentType,
+    // ) -> Result<(), Error> {
+    //     let property_registry: PropertyRegistry = world.read_model((component_type));
+    //     let mut success: bool = false;
+    //     let mut result: Result::<(), Error> = Result::Err((Error::EffectFailed));
+    //     match component_type.clone() {
+    //         ComponentType::Area => {
+    //             let component: Area = world.read_model(*key);
+    //             let prop_text = property_name.clone();
+    //             let (result_p, success_p) = VariablePropertyHelperTrait::set_area_property(
+    //                 component, *world, @prop_text, @property_registry, new_value,
+    //             );
+    //             result = result_p;
+    //             success = success_p;
+    //         },
+    //         ComponentType::Exit => {
+    //             let component: Exit = world.read_model(*key);
+    //             let prop_text = property_name.clone();
+    //             let (result_p, success_p) = VariablePropertyHelperTrait::set_exit_property(
+    //                 component, *world, @prop_text, @property_registry, new_value,
+    //             );
+    //             result = result_p;
+    //             success = success_p;
+    //         },
+    //         ComponentType::Reactable => {
+    //             let component: Reactable = world.read_model(*key);
+    //             let prop_text = property_name.clone();
+    //             let (result_p, success_p) = VariablePropertyHelperTrait::set_reactable_property(
+    //                 component, *world, @prop_text, @property_registry, new_value,
+    //             );
+    //             result = result_p;
+    //             success = success_p;
+    //         },
+    //         ComponentType::InventoryItem => {
+    //             let component: InventoryItem = world.read_model(*key);
+    //             let prop_text = property_name.clone();
+    //             let (result_p, success_p) =
+    //                 VariablePropertyHelperTrait::set_inventory_item_property(
+    //                 component,
+    //                 *world,
+    //                 @prop_text,
+    //                 effect_type,
+    //                 @property_registry,
+    //                 new_value,
+    //                 num_value,
+    //             );
+    //             result = result_p;
+    //             success = success_p;
+    //         },
+    //         ComponentType::Container => {
+    //             let component: Container = world.read_model(*key);
+    //             let prop_text = property_name.clone();
+    //             let (result_p, success_p) = VariablePropertyHelperTrait::set_container_property(
+    //                 component,
+    //                 *world,
+    //                 @prop_text,
+    //                 effect_type,
+    //                 @property_registry,
+    //                 new_value,
+    //                 num_value,
+    //             );
+    //             result = result_p;
+    //             success = success_p;
+    //         },
+    //         ComponentType::Player => {
+    //             let component: Player = world.read_model(*key);
+    //             let prop_text = property_name.clone();
+    //             let (result_p, success_p) = VariablePropertyHelperTrait::set_player_property(
+    //                 component, *world, @prop_text, @property_registry, new_value,
+    //             );
+    //             result = result_p;
+    //             success = success_p;
+    //         },
+    //         _ => { // Do nothing
+    //         },
+    //     }
+    //     return result;
+    // }
 }
 

--- a/packages/contracts/src/lib/variable_property.cairo
+++ b/packages/contracts/src/lib/variable_property.cairo
@@ -93,91 +93,90 @@ pub impl VariablePropertyImp of VariablePropertyTrait {
         }
         return (property_value, access);
     }
-
     // fn set_property(
-    //     mut world: @WorldStorage,
-    //     key: @felt252,
-    //     effect_type: @EffectType,
-    //     property_name: @ByteArray,
-    //     new_value: @Array<(ByteArray, u32)>,
-    //     num_value: @u32,
-    //     component_type: ComponentType,
-    // ) -> Result<(), Error> {
-    //     let property_registry: PropertyRegistry = world.read_model((component_type));
-    //     let mut success: bool = false;
-    //     let mut result: Result::<(), Error> = Result::Err((Error::EffectFailed));
-    //     match component_type.clone() {
-    //         ComponentType::Area => {
-    //             let component: Area = world.read_model(*key);
-    //             let prop_text = property_name.clone();
-    //             let (result_p, success_p) = VariablePropertyHelperTrait::set_area_property(
-    //                 component, *world, @prop_text, @property_registry, new_value,
-    //             );
-    //             result = result_p;
-    //             success = success_p;
-    //         },
-    //         ComponentType::Exit => {
-    //             let component: Exit = world.read_model(*key);
-    //             let prop_text = property_name.clone();
-    //             let (result_p, success_p) = VariablePropertyHelperTrait::set_exit_property(
-    //                 component, *world, @prop_text, @property_registry, new_value,
-    //             );
-    //             result = result_p;
-    //             success = success_p;
-    //         },
-    //         ComponentType::Reactable => {
-    //             let component: Reactable = world.read_model(*key);
-    //             let prop_text = property_name.clone();
-    //             let (result_p, success_p) = VariablePropertyHelperTrait::set_reactable_property(
-    //                 component, *world, @prop_text, @property_registry, new_value,
-    //             );
-    //             result = result_p;
-    //             success = success_p;
-    //         },
-    //         ComponentType::InventoryItem => {
-    //             let component: InventoryItem = world.read_model(*key);
-    //             let prop_text = property_name.clone();
-    //             let (result_p, success_p) =
-    //                 VariablePropertyHelperTrait::set_inventory_item_property(
-    //                 component,
-    //                 *world,
-    //                 @prop_text,
-    //                 effect_type,
-    //                 @property_registry,
-    //                 new_value,
-    //                 num_value,
-    //             );
-    //             result = result_p;
-    //             success = success_p;
-    //         },
-    //         ComponentType::Container => {
-    //             let component: Container = world.read_model(*key);
-    //             let prop_text = property_name.clone();
-    //             let (result_p, success_p) = VariablePropertyHelperTrait::set_container_property(
-    //                 component,
-    //                 *world,
-    //                 @prop_text,
-    //                 effect_type,
-    //                 @property_registry,
-    //                 new_value,
-    //                 num_value,
-    //             );
-    //             result = result_p;
-    //             success = success_p;
-    //         },
-    //         ComponentType::Player => {
-    //             let component: Player = world.read_model(*key);
-    //             let prop_text = property_name.clone();
-    //             let (result_p, success_p) = VariablePropertyHelperTrait::set_player_property(
-    //                 component, *world, @prop_text, @property_registry, new_value,
-    //             );
-    //             result = result_p;
-    //             success = success_p;
-    //         },
-    //         _ => { // Do nothing
-    //         },
-    //     }
-    //     return result;
-    // }
+//     mut world: @WorldStorage,
+//     key: @felt252,
+//     effect_type: @EffectType,
+//     property_name: @ByteArray,
+//     new_value: @Array<(ByteArray, u32)>,
+//     num_value: @u32,
+//     component_type: ComponentType,
+// ) -> Result<(), Error> {
+//     let property_registry: PropertyRegistry = world.read_model((component_type));
+//     let mut success: bool = false;
+//     let mut result: Result::<(), Error> = Result::Err((Error::EffectFailed));
+//     match component_type.clone() {
+//         ComponentType::Area => {
+//             let component: Area = world.read_model(*key);
+//             let prop_text = property_name.clone();
+//             let (result_p, success_p) = VariablePropertyHelperTrait::set_area_property(
+//                 component, *world, @prop_text, @property_registry, new_value,
+//             );
+//             result = result_p;
+//             success = success_p;
+//         },
+//         ComponentType::Exit => {
+//             let component: Exit = world.read_model(*key);
+//             let prop_text = property_name.clone();
+//             let (result_p, success_p) = VariablePropertyHelperTrait::set_exit_property(
+//                 component, *world, @prop_text, @property_registry, new_value,
+//             );
+//             result = result_p;
+//             success = success_p;
+//         },
+//         ComponentType::Reactable => {
+//             let component: Reactable = world.read_model(*key);
+//             let prop_text = property_name.clone();
+//             let (result_p, success_p) = VariablePropertyHelperTrait::set_reactable_property(
+//                 component, *world, @prop_text, @property_registry, new_value,
+//             );
+//             result = result_p;
+//             success = success_p;
+//         },
+//         ComponentType::InventoryItem => {
+//             let component: InventoryItem = world.read_model(*key);
+//             let prop_text = property_name.clone();
+//             let (result_p, success_p) =
+//                 VariablePropertyHelperTrait::set_inventory_item_property(
+//                 component,
+//                 *world,
+//                 @prop_text,
+//                 effect_type,
+//                 @property_registry,
+//                 new_value,
+//                 num_value,
+//             );
+//             result = result_p;
+//             success = success_p;
+//         },
+//         ComponentType::Container => {
+//             let component: Container = world.read_model(*key);
+//             let prop_text = property_name.clone();
+//             let (result_p, success_p) = VariablePropertyHelperTrait::set_container_property(
+//                 component,
+//                 *world,
+//                 @prop_text,
+//                 effect_type,
+//                 @property_registry,
+//                 new_value,
+//                 num_value,
+//             );
+//             result = result_p;
+//             success = success_p;
+//         },
+//         ComponentType::Player => {
+//             let component: Player = world.read_model(*key);
+//             let prop_text = property_name.clone();
+//             let (result_p, success_p) = VariablePropertyHelperTrait::set_player_property(
+//                 component, *world, @prop_text, @property_registry, new_value,
+//             );
+//             result = result_p;
+//             success = success_p;
+//         },
+//         _ => { // Do nothing
+//         },
+//     }
+//     return result;
+// }
 }
 

--- a/packages/contracts/src/lib/variable_property_helper.cairo
+++ b/packages/contracts/src/lib/variable_property_helper.cairo
@@ -3,7 +3,7 @@ use lore::{
     models::{
         index::{
             Area, Exit, Reactable, DescriptionText, InventoryItem, Container, Player,
-            PropertyRegistry,
+            PropertyRegistry, Effect,
         },
         area::AreaComponent, exit::ExitComponent, reactable::ReactableComponent,
         inventoryItem::InventoryItemComponent, container::ContainerComponent,
@@ -519,11 +519,8 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
     fn set_inventory_item_property(
         mut component: InventoryItem,
         mut world: WorldStorage,
-        name: @ByteArray,
-        effect_type: @EffectType,
+        effect: @Effect,
         property: @PropertyRegistry,
-        new_value: @Array<(ByteArray, u32)>,
-        num_value: @u32,
     ) -> (Result::<(), Error>, bool) {
         // Define expected property names
         let owner_id: ByteArray = "owner_id";
@@ -536,13 +533,13 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
         let mut result: Result::<(), Error> = Result::Ok(());
 
         for prop in property.properties.clone() {
-            if prop.name == name.clone() {
+            if prop.name == effect.property.clone() {
                 match prop.access_flags {
                     PropertyAccess::ReadOnly => { result = Result::Err(Error::ReadOnlyVariable); },
                     PropertyAccess::ReadWrite => {
-                        if name == @owner_id {
-                            let (value, _index) = new_value[0].clone();
-                            component.owner_id = value.to_felt252_word().unwrap();
+                        if effect.property == @owner_id {
+                            let new_owner_id = effect.hex_value.clone();
+                            component.owner_id = new_owner_id;
                             // move item to new owner
                             let new_owner_container: Container = world
                                 .read_model(component.owner_id);
@@ -552,25 +549,25 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
                             } else {
                                 success = true;
                             }
-                        } else if name == @can_be_picked_up {
-                            let (value, _index) = new_value[0].clone();
+                        } else if effect.property == @can_be_picked_up {
+                            let (value, _index) = effect.value[0].clone();
                             let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.can_be_picked_up = new_var_value;
                             success = true;
-                        } else if name == @can_go_in_container {
-                            let (value, _index) = new_value[0].clone();
+                        } else if effect.property == @can_go_in_container {
+                            let (value, _index) = effect.value[0].clone();
                             let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.can_go_in_container = new_var_value;
                             success = true;
-                        } else if name == @quantity {
-                            match effect_type.clone() {
+                        } else if effect.property == @quantity {
+                            match effect.effect_type.clone() {
                                 EffectType::AddQuantity => {
-                                    component.quantity += num_value.clone();
+                                    component.quantity += effect.n_value.clone();
                                     success = true;
                                 },
                                 EffectType::RemoveQuantity => {
-                                    if component.quantity >= num_value.clone() {
-                                        component.quantity -= num_value.clone();
+                                    if component.quantity >= effect.n_value.clone() {
+                                        component.quantity -= effect.n_value.clone();
                                         success = true;
                                     } else {
                                         let zero: u32 = 0;
@@ -580,19 +577,19 @@ pub impl VariablePropertyHelper of VariablePropertyHelperTrait {
                                 },
                                 EffectType::ModifyProperty => {
                                     // Overwrite the quantity
-                                    component.quantity = num_value.clone();
+                                    component.quantity = effect.n_value.clone();
                                     success = true;
                                 },
                                 _ => { // Do nothing for now
                                 },
                             }
-                        } else if name == @already_used {
-                            let (value, _index) = new_value[0].clone();
+                        } else if effect.property == @already_used {
+                            let (value, _index) = effect.value[0].clone();
                             let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.already_used = new_var_value;
                             success = true;
-                        } else if name == @multiple_use {
-                            let (value, _index) = new_value[0].clone();
+                        } else if effect.property == @multiple_use {
+                            let (value, _index) = effect.value[0].clone();
                             let new_var_value = ByteArrayTraitExt::bool_from_byte_array(value);
                             component.multiple_use = new_var_value;
                             success = true;

--- a/packages/contracts/src/models/index.cairo
+++ b/packages/contracts/src/models/index.cairo
@@ -172,8 +172,6 @@ pub struct Player {
     pub address: ContractAddress,
     /// The location of the player
     pub location: felt252,
-    /// Current story line
-    pub story_line: CounterType,
     /// If the player is in debug mode
     pub use_debug: bool,
 }
@@ -184,8 +182,8 @@ pub struct PlayerStory {
     #[key]
     pub inst: felt252,
     /// Properties ///
-    /// Array of story lines (story lines keys)
-    pub story: Array<CounterType>,
+    /// Current story line - latest
+    pub story_line: CounterType,
 }
 
 pub type CounterType = u32;

--- a/packages/contracts/src/models/index.cairo
+++ b/packages/contracts/src/models/index.cairo
@@ -320,6 +320,8 @@ pub struct Effect {
     pub value: Array<(ByteArray, u32)>,
     /// for numbers: the value that will add/substract or replace the current value
     pub n_value: u32,
+    // for hex: will be used mostly in owner_id
+    pub hex_value: felt252,
 }
 
 /// NOT USED YET ///

--- a/packages/contracts/src/models/player.cairo
+++ b/packages/contracts/src/models/player.cairo
@@ -99,10 +99,10 @@ mod tests {
         player.say(world, "hello");
         let story: PlayerStory = world.read_model(player.inst);
         // ("story: {:?}", story);
-        assert(story.story.len() == 2, 'story has two entries'); // first entry is intro text
+        let story_key: u32 = 2;
+        assert(story.story_line == 2, 'story has two entries'); // first entry is intro text
         let test_text: ByteArray = "hello";
 
-        let story_key: u32 = *story.story.at(story.story.len() - 1);
         let story_line: StoryLine = world.read_model((story.inst, story_key));
         assert(story_line.line == test_text, 'story has "hello"');
     }

--- a/packages/contracts/src/new_components/action_trait.cairo
+++ b/packages/contracts/src/new_components/action_trait.cairo
@@ -388,8 +388,9 @@ mod tests {
         property: ByteArray,
         value: Array<(ByteArray, u32)>,
         n_value: u32,
+        hex_value: felt252,
     ) -> Effect {
-        Effect { inst, key, name, target, effect_type, component, property, value, n_value }
+        Effect { inst, key, name, target, effect_type, component, property, value, n_value, hex_value }
     }
 
     fn create_test_action(
@@ -526,6 +527,7 @@ mod tests {
 
         let name: ByteArray = "Effect name";
         let name2: ByteArray = "Effect name2";
+        let hex_value: felt252 = 0;
 
         // Create effects
         let mut effect = create_test_effect(
@@ -538,6 +540,7 @@ mod tests {
             property,
             new_description.clone(),
             0,
+            hex_value,
         );
         let mut effect2 = create_test_effect(
             door.inst,
@@ -549,6 +552,7 @@ mod tests {
             property2,
             new_enterable,
             0,
+            hex_value,
         );
         world.write_model(@effect);
         world.write_model(@effect2);
@@ -717,6 +721,7 @@ mod tests {
         let e_key2: felt252 = 2;
         let name: ByteArray = "Effect name";
         let name2: ByteArray = "Effect name2";
+        let hex_value: felt252 = 0;
 
         // Create effects
         let mut effect = create_test_effect(
@@ -729,6 +734,7 @@ mod tests {
             property,
             new_description.clone(),
             0,
+            hex_value,
         );
         let mut effect2 = create_test_effect(
             door.inst,
@@ -740,6 +746,7 @@ mod tests {
             property2,
             new_enterable.clone(),
             0,
+            hex_value,
         );
         world.write_model(@effect);
         world.write_model(@effect2);

--- a/packages/contracts/src/new_components/action_trait.cairo
+++ b/packages/contracts/src/new_components/action_trait.cairo
@@ -390,7 +390,9 @@ mod tests {
         n_value: u32,
         hex_value: felt252,
     ) -> Effect {
-        Effect { inst, key, name, target, effect_type, component, property, value, n_value, hex_value }
+        Effect {
+            inst, key, name, target, effect_type, component, property, value, n_value, hex_value,
+        }
     }
 
     fn create_test_action(

--- a/packages/contracts/src/new_components/effect_trait.cairo
+++ b/packages/contracts/src/new_components/effect_trait.cairo
@@ -78,10 +78,7 @@ pub impl EffectImpl of EffectTrait {
                 // Direct modification to component
                 let (result_p, _success_p) =
                     VariablePropertyHelperTrait::set_inventory_item_property(
-                    item,
-                    world,
-                    self,
-                    @property_registry,
+                    item, world, self, @property_registry,
                 );
                 result = result_p;
             },
@@ -156,7 +153,9 @@ mod tests {
         n_value: u32,
         hex_value: felt252,
     ) -> Effect {
-        Effect { inst, key, name, target, effect_type, component, property, value, n_value, hex_value }
+        Effect {
+            inst, key, name, target, effect_type, component, property, value, n_value, hex_value,
+        }
     }
 
     fn create_trigger_context(

--- a/packages/contracts/src/new_components/effect_trait.cairo
+++ b/packages/contracts/src/new_components/effect_trait.cairo
@@ -80,11 +80,8 @@ pub impl EffectImpl of EffectTrait {
                     VariablePropertyHelperTrait::set_inventory_item_property(
                     item,
                     world,
-                    self.property,
-                    self.effect_type,
+                    self,
                     @property_registry,
-                    self.value,
-                    self.n_value,
                 );
                 result = result_p;
             },
@@ -157,8 +154,9 @@ mod tests {
         property: ByteArray,
         value: Array<(ByteArray, u32)>,
         n_value: u32,
+        hex_value: felt252,
     ) -> Effect {
-        Effect { inst, key, name, target, effect_type, component, property, value, n_value }
+        Effect { inst, key, name, target, effect_type, component, property, value, n_value, hex_value }
     }
 
     fn create_trigger_context(
@@ -218,6 +216,7 @@ mod tests {
         let key: felt252 = 1;
         let name: ByteArray = "Effect name";
         let n_value: u32 = 0;
+        let hex_value: felt252 = 0;
         let mut effect = create_test_effect(
             door.inst,
             key,
@@ -228,6 +227,7 @@ mod tests {
             "description",
             new_value.clone(),
             n_value,
+            hex_value,
         );
         world.write_model(@effect);
         let result = effect.apply_effect(world, context);

--- a/packages/contracts/src/new_components/player_trait.cairo
+++ b/packages/contracts/src/new_components/player_trait.cairo
@@ -64,60 +64,48 @@ pub impl PlayerImpl of PlayerTrait {
     }
 
     // TODO: improve name and better description
-    fn say(mut self: @Player, mut world: WorldStorage, text: ByteArray) {
-        let mut player: Player = world.read_model(*self.inst);
-        let mut counter: u32 = player.story_line;
+    fn say(self: @Player, mut world: WorldStorage, text: ByteArray) {
+        let mut story: PlayerStory = world.read_model(*self.inst);
+        // Get the current story line counter
+        let counter: u32 = story.story_line;
         let increase: u32 = 1;
+        // Increase the counter
         let new_counter: u32 = counter + increase;
-
+        // Create a new story line
         let story_line = StoryLine { inst: *self.inst, key: new_counter, line: text };
         world.write_model(@story_line);
 
-        let mut player_story: PlayerStory = world.read_model(*self.inst);
-        player_story.story.append(new_counter);
-        // world
-        //     .write_member(
-        //         Model::<PlayerStory>::ptr_from_keys(*self.inst),
-        //         selector!("story"),
-        //         player_story.story.span(),
-        //     );
-        world.write_model(@player_story);
-
-        // Update the player
-        let mut player: Player = world.read_model(*self.inst);
-        player.story_line = new_counter;
+        // Set the new story line counter
+        story.story_line = new_counter;
         world
             .write_member(
-                Model::<Player>::ptr_from_keys(*self.inst),
+                Model::<PlayerStory>::ptr_from_keys(*self.inst),
                 selector!("story_line"),
-                player.story_line,
+                story.story_line,
             );
-        //player.store(world);
     }
 
 
-    fn add_command_text(mut self: @Player, mut world: WorldStorage, text: ByteArray) {
-        // read counter from player
-        let mut counter = *self.story_line;
+    fn add_command_text(self: @Player, mut world: WorldStorage, text: ByteArray) {
+        // read counter from PlayerStory
+        let mut story: PlayerStory = world.read_model(*self.inst);
+        let mut counter = story.story_line;
         // increase counter
         let increase: u32 = 1;
-        counter += increase;
+        let new_counter = counter + increase;
         // create new story line
-        let mut story_line = StoryLine { inst: *self.inst, key: counter, line: text };
+        let mut story_line = StoryLine { inst: *self.inst, key: new_counter, line: text };
         // write story line to world
         world.write_model(@story_line);
-        // add story line to player story
-        let mut player_story: PlayerStory = world.read_model(*self.inst);
-        player_story.story.append(counter);
-        // update player_story.story
-        world.write_model(@player_story);
-        // let mut playerStory: PlayerStory = world.read_model(*self.inst);
-    // let mut storyLine = playerStory.story.clone();
-    // if (storyLine.len() > 10) {
-    //     let _ = storyLine.pop_front();
-    // }
-    // storyLine.append(format!("> {}", text));
-    // world.write_model(@PlayerStory { inst: *self.inst, story: storyLine });
+
+        // update PlayerStory
+        story.story_line = new_counter;
+        world
+            .write_member(
+                Model::<PlayerStory>::ptr_from_keys(*self.inst),
+                selector!("story_line"),
+                story.story_line,
+            );
     }
 
     fn get_room(self: @Player, world: @WorldStorage) -> Option<Entity> {

--- a/packages/contracts/src/new_components/player_trait.cairo
+++ b/packages/contracts/src/new_components/player_trait.cairo
@@ -77,12 +77,13 @@ pub impl PlayerImpl of PlayerTrait {
 
         // Set the new story line counter
         story.story_line = new_counter;
-        world
-            .write_member(
-                Model::<PlayerStory>::ptr_from_keys(*self.inst),
-                selector!("story_line"),
-                story.story_line,
-            );
+        // world
+        //     .write_member(
+        //         Model::<PlayerStory>::ptr_from_keys(*self.inst),
+        //         selector!("story_line"),
+        //         story.story_line,
+        //     );
+        world.write_model(@story);
     }
 
 


### PR DESCRIPTION
# Description

This PR cover:
- Upgrade of dojo version.
- PlayerStory: the model no longer stores an array of all the keys created but rather uses a counter to store the number of story lines created. An update in the client package was made to subscribe and output the created story lines.
- Set Inventory Item owner id: there was an adjustment on how the change of owner was happening when changing the `onwer_id` of the `inventoryItem` through the `Effect` model.
-Improvements on client package: when logging to wallet no longer ask permission for each action but rather as a whole group (necessary when login for first time as this will create your player). Added story line to player entity, fixed its creation.

## Related issues

Closes #197 #198 #199 #200

## Introduced changes

- PlayerStory: the model no longer stores an array of all the keys created but rather uses a counter to store the number of story lines created. Also, instead of having the counter in the `Player` model it was changed to `PlayerStory`. Each time a new story line is generated it will get the counter, increase by one and use it as key to create story line, story story line and update the player story.

On client package, it no longer requires to map the keys as we use directly the counter to get all the story lines from the last story line printed to the newest one (updated).
 
 
-  Set Inventory Item owner id: there was an adjustment on how the change of owner was happening. A new variable was added to `Effect` model as we needed a clean hex to use it as the function that was being used to convert from `ByteArray` to `felt252` was not ideal for the value. The new variable is used directly. The necessary change was made in the `EffectInspector.tsx` file.

- When connecting to your wallet via game (no editor) it was check if the user needed to create his `player` and if so it required to approve each transaction. Now all transactions are in a single package for approval. 
- Also the registration of the variable properties will happen when you connect. If there is no property registry it will call for it if not skip it.
- In the editor a minor fix for setting triggers, conditions, effects entities in the action inspector. Now its possible to scroll up, down and the list will move as needed. This solves the large list of entities and not being able to find it.

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
