### PR TITLE
chore: adjust collaborative pipeline. Owner now published all changes

### DIFF
--- a/docs/Collaborative Feature/collab-api.md
+++ b/docs/Collaborative Feature/collab-api.md
@@ -8,75 +8,63 @@ This document is the authoritative reference for both the **Cairo contract API**
 
 1. [Overview](#overview)
 2. [Data types](#data-types)
-   - [ApprovedProposal (Cairo model)](#approvedproposal-cairo-model)
+   - [CollabReviewResult (Cairo model)](#collabrevid-result-cairo-model)
    - [CollabProposalEvent (Cairo event)](#collabproposaleventslow-cairo-event)
-   - [ApprovedProposal (TypeScript)](#approvedproposal-typescript)
+   - [CollabReviewResult (TypeScript)](#collabrevid-result-typescript)
    - [ChangeSet (TypeScript)](#changeset-typescript)
 3. [Contract API — `IDesigner`](#contract-api--idesigner)
    - [Access control](#access-control)
    - [submit_for_review](#submit_for_review)
-   - [approve_proposal](#approve_proposal)
-   - [reject_proposal](#reject_proposal)
+   - [signal_review_result](#signal_review_result)
    - [Approval gate on create_* / delete_*](#approval-gate-on-create--delete-)
    - [Error codes](#error-codes)
 4. [Client API — `publisher.ts`](#client-api--publisherts)
    - [submitForReview](#submitforreview)
-   - [publishApproved](#publishapproved)
+   - [publishFromProposal](#publishfromproposal)
+   - [signalReviewResult](#signalreviewresult)
    - [publishConfigToContract](#publishconfigtocontract)
 5. [Torii queries](#torii-queries)
 6. [Component classification](#component-classification)
-7. [Approval array encoding](#approval-array-encoding)
 
 ---
 
 ## Overview
 
-The collab feature is a two-phase commit over Dojo events and models:
+The collab feature is a proposal-based flow where the **trail owner publishes approved content** on behalf of the collaborator:
 
 | Phase | Who | What | On-chain effect |
 |---|---|---|---|
 | 1. Submit | Collaborator | `submit_for_review` | Emits `CollabProposalEvent` — **zero storage written** |
-| 2. Approve | Trail owner | `approve_proposal` | Writes `ApprovedProposal` model (inst IDs only) |
-| 3. Publish | Collaborator | Normal `create_*` / `delete_*` | Full entity + component models written; contract checks approval gate |
-| — | Trail owner | `reject_proposal` | Erases `ApprovedProposal`; no revert needed |
+| 2. Publish | Trail owner | `publishFromProposal` (client) → `create_*` / `delete_*` | Full entity + component models written |
+| 3. Signal | Trail owner | `signal_review_result` | Writes `CollabReviewResult` model (counts only) |
+| — | Collaborator | Receives `CollabReviewResult` via Torii | Toast notification / rejection banner |
 
-Trail owners bypass phases 1–2 entirely and call `create_*` / `delete_*` directly.
+Trail owners bypass phase 1 entirely and call `create_*` / `delete_*` directly. Collaborators can **never** call `create_*` / `delete_*` on a trail they don't own.
 
 ---
 
 ## Data types
 
-### `ApprovedProposal` (Cairo model)
+### `CollabReviewResult` (Cairo model)
 
 ```cairo
 // packages/contracts/src/models/collab_proposal.cairo
 
 #[derive(Clone, Drop, Serde, Introspect)]
 #[dojo::model]
-pub struct ApprovedProposal {
-    #[key] pub trail_id: u128,
-    #[key] pub proposer: ContractAddress,
-
-    // Writes — single-key components (Entity, Reactable, Area, Exit, Hub,
-    //          InventoryItem, Container, Trail, ParentToChildren, ChildToParent)
-    pub w_single_keys:       Array<felt252>,  // flat list of inst values
-
-    // Writes — DescriptionText (keyed by inst + u32)
-    pub w_description_texts: Array<felt252>,  // flat pairs [inst, key_as_felt252, ...]
-
-    // Writes — multi-key components (Trigger, Condition, Effect, Action)
-    pub w_multi_keys:        Array<felt252>,  // flat pairs [inst, key, ...]
-
-    // Deletes — same bucket structure as writes
-    pub d_single_keys:       Array<felt252>,
-    pub d_description_texts: Array<felt252>,
-    pub d_multi_keys:        Array<felt252>,
+pub struct CollabReviewResult {
+    #[key] pub trail_id:       u128,
+    #[key] pub proposer:       ContractAddress,
+    pub published_count:       u32,
+    pub skipped_count:         u32,
 }
 ```
 
-**Keys**: `(trail_id, proposer)` — one record per collaborator per trail. Writing a new `ApprovedProposal` for the same key pair overwrites the previous one. At most one pending approval per collaborator exists at any moment.
+**Keys**: `(trail_id, proposer)` — one record per collaborator per trail. Writing a new `CollabReviewResult` for the same key pair overwrites the previous one.
 
-**Storage**: only `felt252` inst / key identifiers are stored — no component data. Cost is proportional to the number of approved items.
+**Storage**: minimal — 2 u32 counts plus keys. Cost is negligible.
+
+**Delivery**: arrives through the existing `subscribeEntityQuery` in `dojo.ts` (same channel as regular model updates) — no separate event subscription needed.
 
 ---
 
@@ -135,27 +123,23 @@ pub struct CollabProposalEvent {
 
 ---
 
-### `ApprovedProposal` (TypeScript)
+### `CollabReviewResult` (TypeScript)
 
 Generated from the Cairo model by Dojo:
 
 ```typescript
 // packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
 
-export interface ApprovedProposal {
+export interface CollabReviewResult {
     fieldOrder: string[];
-    trail_id:          BigNumberish;
-    proposer:          string;          // hex address
-    w_single_keys:     BigNumberish[];
-    w_description_texts: BigNumberish[];
-    w_multi_keys:      BigNumberish[];
-    d_single_keys:     BigNumberish[];
-    d_description_texts: BigNumberish[];
-    d_multi_keys:      BigNumberish[];
+    trail_id:        BigNumberish;
+    proposer:        string;      // hex address
+    published_count: number;
+    skipped_count:   number;
 }
 ```
 
-Torii delivers instances of this type via the SDK subscription. `publishApproved` consumes one instance.
+Torii delivers instances of this type via the entity subscription. `StagingPanel` watches it to show toast notifications or the rejection banner.
 
 ---
 
@@ -174,7 +158,7 @@ export type ChangeSet = {
 };
 ```
 
-`EditorCollection` is a partial map of component name → component data (with Cairo enums replaced by their string union equivalents). Both `submitForReview` and `publishApproved` consume `ChangeSet[]` arrays read from `EditorData().stagedChanges`.
+`EditorCollection` is a partial map of component name → component data. `submitForReview` consumes `ChangeSet[]` arrays read from `EditorData().stagedChanges`.
 
 ---
 
@@ -270,47 +254,40 @@ fn submit_for_review(
 
 **Effect**: emits one `CollabProposalEvent`. **No storage written.**
 
+**Restriction**: `deleted_entity_insts` must be empty for non-owner callers. Collaborators can propose component-level deletions but not entity-level deletions.
+
 **Panics**:
 - `NOT_EDITOR` — caller has no editor-level role at all
 - `NOT_COLLABORATOR` — caller passes layer 1 but does not hold a role on this trail and is not the trail owner / admin
+- `NOT_TRAIL_OWNER` — caller is a collaborator and passed a non-empty `deleted_entity_insts`
 
-**Cost**: collaborator pays; gas scales with calldata size (total byte length of all arrays). Empty arrays each cost 1 felt252 (the length prefix 0). Recommended to only populate arrays that have actual changes.
+**Cost**: collaborator pays; gas scales with calldata size. Recommended to only populate arrays that have actual changes.
 
 ---
 
-### `approve_proposal`
+### `signal_review_result`
 
 ```cairo
-fn approve_proposal(ref self: TContractState, proposal: ApprovedProposal)
+fn signal_review_result(
+    ref self: TContractState,
+    trail_id:        u128,
+    proposer:        ContractAddress,
+    published_count: u32,
+    skipped_count:   u32,
+)
 ```
 
 **Caller**: trail owner or admin.
 
-**Effect**: writes `ApprovedProposal` model to World storage, keyed by `(proposal.trail_id, proposal.proposer)`. Any previous approval for the same key is overwritten.
+**Effect**: writes `CollabReviewResult` model to World storage, keyed by `(trail_id, proposer)`. Any previous result for the same key is overwritten.
 
-**Panics**: `NOT_TRAIL_OWNER` — caller is not admin and does not own `proposal.trail_id`.
+**Panics**: `NOT_TRAIL_OWNER` — caller is not admin and does not own `trail_id`.
 
-**Cost**: trail owner pays; cost scales with the number of inst/key values across the 6 arrays (typically tens of felt252 values — very cheap).
+**Cost**: trail owner pays; trivial (2 u32 fields).
 
-**Partial approval**: the owner can pass non-empty arrays for some component types and empty arrays for others. Empty `w_single_keys` means no single-key writes are approved; empty `d_single_keys` means no deletions are approved. The collaborator's subsequent `create_*` / `delete_*` calls will panic for unapproved items.
+**When to call**: after calling `publishFromProposal` (or after deciding to skip all items). The owner passes the exact counts returned by `publishFromProposal` to give the collaborator an accurate notification.
 
----
-
-### `reject_proposal`
-
-```cairo
-fn reject_proposal(ref self: TContractState, trail_id: u128, proposer: ContractAddress)
-```
-
-**Caller**: trail owner or admin.
-
-**Effect**: erases the `ApprovedProposal` model for `(trail_id, proposer)` from World storage. The `CollabProposalEvent` remains in Torii as a record of the original proposal.
-
-**Panics**: `NOT_TRAIL_OWNER`.
-
-**Cost**: trail owner pays; erasing a model is a trivial write.
-
-**After rejection**: the collaborator receives no on-chain notification. The client detects rejection by watching the `ApprovedProposal` model disappear from Torii while staged changes remain (see `StagingPanel.tsx` rejection banner logic).
+**Full rejection**: call with `published_count = 0` and `skipped_count = total proposal items`. The collaborator receives the rejection banner and their staged changes are preserved.
 
 ---
 
@@ -324,36 +301,28 @@ if !owned.is_zero()                              // (1) not an admin
    && trail_id.is_non_zero()                     // (2) entity belongs to a trail
    && !world.is_owner_of_trail(trail_id, owned)  // (3) caller is not the trail owner
 {
-    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-
-    // Single-key component write (Entity, Area, Reactable, Exit, Hub, ...):
-    assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
-
-    // DescriptionText write:
-    assert(contains_pair(approval.w_description_texts.span(), o.inst, o.key.into()), Errors::NOT_APPROVED);
-
-    // Multi-key write (Trigger, Condition, Effect, Action):
-    assert(contains_pair(approval.w_multi_keys.span(), o.inst, o.key), Errors::NOT_APPROVED);
-
-    // Single-key delete:
-    assert(contains_inst(approval.d_single_keys.span(), inst), Errors::NOT_APPROVED);
-
-    // DescriptionText delete:
-    assert(contains_pair(approval.d_description_texts.span(), inst, key), Errors::NOT_APPROVED);
-
-    // Multi-key delete:
-    assert(contains_pair(approval.d_multi_keys.span(), inst, key), Errors::NOT_APPROVED);
+    assert(false, Errors::NOT_APPROVED);  // unconditional — collaborators never write directly
 }
 ```
 
-The `contains_inst` and `contains_pair` free functions live in `collab_proposal.cairo`:
+There is no approval list to look up. The check is purely: **if you are a non-owner collaborator, you cannot write**. The trail owner is expected to call these functions directly when publishing a collaborator's proposal.
+
+**`creator_address` for new entities**: when the owner publishes a new entity (one that doesn't yet exist on-chain), they pass the collaborator's address as `creator_address` in the `Entity` struct. The contract uses this value for new entities and ignores it for existing ones (always preserving the stored creator).
 
 ```cairo
-pub fn contains_inst(mut list: Span<felt252>, inst: felt252) -> bool { ... }
-pub fn contains_pair(mut list: Span<felt252>, inst: felt252, key: felt252) -> bool { ... }
+// Inside create_entity — creator resolution
+if stored_entity.creator_address.is_zero() {
+    // new entity: use passed value if non-zero, otherwise use caller
+    entity.creator_address = if o.creator_address.is_non_zero() {
+        o.creator_address
+    } else {
+        owned
+    };
+} else {
+    // existing entity: always preserve stored creator
+    entity.creator_address = stored_entity.creator_address;
+}
 ```
-
-**Important for new entities**: when calling `create_entity` for a new entity, the entity does not yet exist in storage, so the gate reads `trail_id` from `o.trail_id` (the field set by the collaborator), not from storage. The collaborator must set the correct `trail_id` on the entity struct.
 
 ---
 
@@ -363,8 +332,8 @@ pub fn contains_pair(mut list: Span<felt252>, inst: felt252, key: felt252) -> bo
 |---|---|---|
 | `NOT_EDITOR` | `'DESIGNER: Not editor'` | `_assert_caller_is_editor` (first layer, all write/delete fns) |
 | `NOT_YOUR_TRAIL` | `'DESIGNER: Not your trail'` | `create_entity`, component fns (second layer) |
-| `NOT_APPROVED` | `'DESIGNER: Not approved'` | Approval gate (third layer) |
-| `NOT_TRAIL_OWNER` | `'DESIGNER: Not trail owner'` | `approve_proposal`, `reject_proposal`, `grant_access_to_trail` |
+| `NOT_APPROVED` | `'DESIGNER: Not approved'` | Approval gate (third layer — unconditional for non-owners) |
+| `NOT_TRAIL_OWNER` | `'DESIGNER: Not trail owner'` | `signal_review_result`, `grant_access_to_trail`, `submit_for_review` (entity deletion) |
 | `NOT_COLLABORATOR` | `'DESIGNER: Not collaborator'` | `submit_for_review` |
 
 ---
@@ -385,7 +354,7 @@ Collects all staged changes for `trailId` from `EditorData().stagedChanges`, ser
 
 **Effect**: calls `submit_for_review` on the designer contract. No models written. Shows a success toast on completion.
 
-**Serialization**: each component type is serialized into its raw Cairo array format using the `build*Data` helpers (mirrors the `publish*` functions used for direct publishing). The complete calldata order is:
+**Serialization**: each component type is serialized into its raw Cairo array format. The complete calldata order is:
 
 ```
 trail_id,
@@ -402,77 +371,61 @@ trail_id,
 [deleted_condition_keys], [deleted_effect_keys], [deleted_action_keys]
 ```
 
-Each `[array]` is encoded as `[length, ...flat_items]` (Cairo array encoding). The `flatCairo` helper produces this format.
+Each `[array]` is encoded as `[length, ...flat_items]` (Cairo array encoding).
 
 ---
 
-### `publishApproved`
+### `publishFromProposal`
 
 ```typescript
-export const publishApproved = async (
-    trailId:  bigint,
-    approval: ApprovedProposal,
-): Promise<boolean>
+export const publishFromProposal = async (
+    proposal: CollabProposalEvent,
+    selected: Set<string>,
+): Promise<{ publishedCount: number; skippedCount: number }>
 ```
 
-Publishes only the staged components that the trail owner approved, using the `ApprovedProposal` to filter. Bypasses the creator-address ownership check (the contract's approval gate enforces access instead).
+Called by the trail owner after reviewing the proposal. Publishes only the items whose keys appear in `selected`, then returns the counts for `signal_review_result`.
 
-**Returns**: `true` on success, `false` if nothing staged or the transaction fails.
+**Parameters**:
+- `proposal` — the `CollabProposalEvent` received from Torii
+- `selected` — set of selection keys (see format below)
+
+**Returns**: `{ publishedCount, skippedCount }` where `publishedCount + skippedCount = totalSelectableKeys`.
 
 **Effect**:
-1. Reads `EditorData().stagedChanges` filtered to `trailId`.
-2. Calls `buildFiltered` for each `ChangeSet` to keep only approved components.
-3. Pass 1: publishes entity data (all components except relationships) for each approved update.
-4. Pass 2: publishes relationships and processes approved deletes.
-5. Removes published entries from `stagedChanges` and `changeSet`.
-6. Removes the consumed `ApprovedProposal` from `EditorData().currentApprovals` (clears the "Approved by trail owner" banner).
-7. Re-syncs published entities from Torii.
+1. Builds lookup maps for all proposal items (entity by inst, components by inst, multi-key components by inst+key).
+2. Builds the full list of selectable keys from the proposal.
+3. Pass 1: publishes entity data for all selected `w:` keys — for each new entity, passes the proposer's address as `creatorAddress`.
+4. Pass 2: publishes relationships (`ParentToChildren` / `ChildToParent`) and executes deletions for `d:` keys.
+5. Returns `{ publishedCount, skippedCount }`.
 
-**`buildFiltered` logic** (per `ChangeSet`):
+**Selection key format**:
 
-```typescript
-// Selects approved components from one ChangeSet's object.
-const buildFiltered = (
-    singleList: bigint[],  // w_single_keys or d_single_keys
-    descList:   bigint[],  // w_description_texts or d_description_texts
-    multiList:  bigint[],  // w_multi_keys or d_multi_keys
-): EditorCollection => {
-    // Single-key components: inst must appear in singleList
-    if (col.Entity     && containsInst(singleList, inst)) out.Entity = col.Entity;
-    if (col.Area       && containsInst(singleList, inst)) out.Area   = col.Area;
-    // ... Reactable, Exit, Hub, InventoryItem, Container, Trail,
-    //     ParentToChildren, ChildToParent (same pattern)
+| Key format | Meaning |
+|---|---|
+| `w:${inst}:${comp}` | Write a single-key component (Entity, Area, Reactable, etc.) |
+| `w:${inst}:${comp}:${key}` | Write a multi-key component (DescriptionText, Trigger, Condition, Effect, Action) |
+| `d:${inst}:${comp}` | Delete a single-key component |
+| `d:${inst}:${comp}:${key}` | Delete a multi-key component |
 
-    // DescriptionText: each (inst, key) pair checked against descList
-    if (col.DescriptionText) {
-        const ok = filterApprovedMulti(descList, col.DescriptionText);
-        if (ok.length > 0) out.DescriptionText = ok;
-    }
+`RemoteChangesPanel` builds these keys via `buildSelectableKeys(proposal)` and stores the owner's selection in a `Set<string>`.
 
-    // Multi-key: Trigger, Condition, Effect, Action — each (inst, key) checked against multiList
-    applyMulti(col.Trigger,   "Trigger");
-    applyMulti(col.Condition, "Condition");
-    applyMulti(col.Effect,    "Effect");
-    applyMulti(col.Action,    "Action");
+---
 
-    return out;
-};
-```
-
-Uses `dSingle / dDesc / dMulti` for `delete` changes, `wSingle / wDesc / wMulti` for `update` changes.
-
-**Membership helpers** (client-side mirrors of the Cairo contract functions):
+### `signalReviewResult`
 
 ```typescript
-const containsInst = (list: bigint[], inst: bigint) =>
-    list.some(x => x === inst);
-
-const containsPair = (list: bigint[], inst: bigint, key: bigint) => {
-    for (let i = 0; i + 1 < list.length; i += 2)
-        if (list[i] === inst && list[i + 1] === key) return true;
-    return false;
-};
+export const signalReviewResult = async (
+    trailId:        bigint,
+    proposer:       string,
+    publishedCount: number,
+    skippedCount:   number,
+): Promise<void>
 ```
+
+Thin re-export wrapping `SystemCalls.signalReviewResult`. Called by the owner after `publishFromProposal` completes.
+
+**Effect**: calls `signal_review_result` on the designer contract, writing `CollabReviewResult` for the given `(trailId, proposer)` pair.
 
 ---
 
@@ -494,7 +447,7 @@ Trail owners and admins use this to publish staged changes directly (bypassing t
 
 **Guard**: skips changes owned by another editor (non-admin callers) and shows a warning toast.
 
-**Not for collaborators**: the `StagingPanel` disables the "Publish staged" button for collaborators who do not own the active trail (`!canPublishDirectly`). Collaborators must use `submitForReview` instead.
+**Not for collaborators**: the `StagingPanel` disables the "Publish staged" button for collaborators who do not own the active trail. Collaborators must use `submitForReview` instead.
 
 ---
 
@@ -522,109 +475,49 @@ const result = await sdk.getEventMessages({ query });
 const proposals = result?.getItems() ?? [];
 ```
 
-### Subscribing to approvals (collaborator)
+### Receiving review results (collaborator)
 
-The collaborator subscribes to `ApprovedProposal` keyed by `(trailId, myAddress)`:
+`CollabReviewResult` is a Dojo **model**, not an event. It arrives through the existing entity subscription in `dojo.ts` alongside all other model updates — no separate query needed:
 
 ```typescript
-const query = new ToriiQueryBuilder<SchemaType>()
-    .withClause(
-        new ClauseBuilder<SchemaType>()
-            .keys(
-                ["lore-ApprovedProposal"],
-                [toHex(trailId), myAddress],
-            )
-            .build()
-    )
-    .withEntityModels(["lore-ApprovedProposal"]);
+// dojo.ts — withEntityModels subscription (excerpt)
+.withEntityModels([
+    "lore-Entity",
+    // ... other models ...
+    "lore-CollabReviewResult",    // ← added to existing subscription
+])
 ```
 
-When a new `ApprovedProposal` arrives, `EditorData().currentApprovals` is updated, triggering the "Approved by trail owner" section in `StagingPanel`.
+In `editor.data.ts`, the `dojoSync` handler extracts it:
 
-### Proposal state machine
+```typescript
+const reviewResult = (obj as any).CollabReviewResult as CollabReviewResult | undefined;
+if (reviewResult?.trail_id !== undefined) {
+    set({ reviewResult });
+    return;
+}
+```
 
-| `CollabProposalEvent` in Torii | `ApprovedProposal` model | Displayed state |
+`StagingPanel` then reads `reviewResult` from `useEditorData()` and applies the three-state notification logic.
+
+### Proposal state
+
+| `CollabProposalEvent` in Torii | `CollabReviewResult` for proposer | State |
 |---|---|---|
-| Yes | No | **Pending** — owner needs to review |
-| Yes | Yes | **Approved** — collaborator can publish |
+| Yes | No (or stale) | **Pending** — owner needs to review and publish |
+| Yes | Yes (recent, `published_count > 0`) | **Published** — result delivered |
+| Yes | Yes (`published_count == 0`) | **Rejected** — result delivered, B can resubmit |
 | No | No | Idle — nothing pending |
-| No | Yes (stale) | Should not occur; approval erased on publish |
 
 ---
 
 ## Component classification
 
-The approval arrays use three buckets. Every component falls into exactly one:
+For the purposes of `publishFromProposal` selection keys, components fall into two categories:
 
-| Bucket | Array fields | Components |
+| Category | Selection key format | Components |
 |---|---|---|
-| **Single-key** | `w_single_keys` / `d_single_keys` | `Entity`, `Reactable`, `Area`, `Exit`, `Hub`, `InventoryItem`, `Container`, `Trail`, `ParentToChildren`, `ChildToParent` |
-| **DescriptionText** | `w_description_texts` / `d_description_texts` | `DescriptionText` (keyed by `inst` + `u32 key`) |
-| **Multi-key** | `w_multi_keys` / `d_multi_keys` | `Trigger`, `Condition`, `Effect`, `Action` (keyed by `inst` + `felt252 key`) |
+| **Single-key** | `w:${inst}:${comp}` / `d:${inst}:${comp}` | `Entity`, `Reactable`, `Area`, `Exit`, `Hub`, `InventoryItem`, `Container`, `Trail`, `ParentToChildren`, `ChildToParent` |
+| **Multi-key** | `w:${inst}:${comp}:${key}` / `d:${inst}:${comp}:${key}` | `DescriptionText` (u32 key), `Trigger`, `Condition`, `Effect`, `Action` (felt252 key) |
 
-**Why DescriptionText is separate**: the owner must be able to approve structural changes (area bounds, reactable settings) while independently rejecting written content (description text). The three-bucket design captures this at the contract level without per-component arrays.
-
-**Per-component granularity for single-key types**: the contract's `w_single_keys` list cannot distinguish "approve Area but not Entity" for the same inst — if an inst is present, all single-key writes for that inst are permitted. Finer granularity for single-key types is enforced **client-side** by `publishApproved`'s `buildFiltered`: only the components the owner checked in the UI are included in the actual `create_*` calls, even though the contract would permit all of them.
-
----
-
-## Approval array encoding
-
-### Single-key arrays (`w_single_keys`, `d_single_keys`)
-
-Flat list of `felt252` inst values:
-
-```cairo
-// Approve writes for ENTITY_A and ENTITY_C
-w_single_keys = array![ENTITY_A, ENTITY_C];
-
-// Check in create_area / create_reactable / etc.
-assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
-```
-
-### DescriptionText arrays (`w_description_texts`, `d_description_texts`)
-
-Flat consecutive pairs `[inst₁, key₁_as_felt252, inst₂, key₂_as_felt252, ...]`:
-
-```cairo
-// Approve DescriptionText (ENTITY_C, key=1) and (ENTITY_A, key=2)
-w_description_texts = array![ENTITY_C, 1, ENTITY_A, 2];
-
-// Check in create_description_text (note: u32 key cast to felt252)
-assert(
-    contains_pair(approval.w_description_texts.span(), o.inst, o.key.into()),
-    Errors::NOT_APPROVED,
-);
-```
-
-### Multi-key arrays (`w_multi_keys`, `d_multi_keys`)
-
-Flat consecutive pairs `[inst₁, key₁, inst₂, key₂, ...]` (both `felt252`):
-
-```cairo
-// Approve Action (ENTITY_A, key=0xdeadbeef) and Trigger (ENTITY_C, key=0xcafe)
-w_multi_keys = array![ENTITY_A, 0xdeadbeef, ENTITY_C, 0xcafe];
-
-// Check in create_action / create_trigger / etc. (key stays felt252)
-assert(
-    contains_pair(approval.w_multi_keys.span(), o.inst, o.key),
-    Errors::NOT_APPROVED,
-);
-```
-
-### Deletion arrays
-
-Deletion arrays follow the same encoding as their write counterparts:
-
-```cairo
-// Entity deletion (single-key bucket)
-d_single_keys = array![ENTITY_B];
-
-// DescriptionText deletion (inst + key pair)
-d_description_texts = array![ENTITY_C, 2];
-
-// Action deletion (inst + key pair)
-d_multi_keys = array![ENTITY_A, 0xdeadbeef];
-```
-
-**Note**: entity deletions (`deleted_entity_insts`) are a subset of single-key deletions. Because deleting an entity implies deleting all its components, the client sends the entity's inst in `d_single_keys` when approving an entity deletion via `buildApprovedProposal`.
+This classification determines the key format used in the selection `Set<string>` and how `publishFromProposal` looks up items in the proposal lookup maps.

--- a/docs/Collaborative Feature/collab-implementation.md
+++ b/docs/Collaborative Feature/collab-implementation.md
@@ -1,6 +1,6 @@
 # Collaborative Trail Editing — Implementation
 
-This document describes the contract-side implementation of the collaborative trail editing approval flow. For the original option analysis see [collab-proposals-flow.md](collab-proposals-flow.md).
+This document describes the contract-side implementation of the collaborative trail editing feature. For the original option analysis see [collab-proposals-flow.md](collab-proposals-flow.md).
 
 ---
 
@@ -8,78 +8,43 @@ This document describes the contract-side implementation of the collaborative tr
 
 Trail tokens are ERC-721 NFTs. The owner of a trail token is the authoritative publisher of all content (entities + components) inside that trail. When a collaborator is invited, they need a way to propose changes without being able to publish content directly to the chain — because once data is on-chain it is live in the game immediately.
 
-The chosen approach is a **two-phase commit with per-component-type granularity**:
+The chosen approach is **proposal event + owner publishes**:
 
 1. The collaborator stages changes locally, then calls `submit_for_review` which emits a Dojo **event** (no storage written — nothing reaches the game world).
-2. The trail owner reviews the proposal off-chain via Torii, then calls `approve_proposal` writing a lightweight `ApprovedProposal` model that lists exactly which component types they accept.
-3. The collaborator calls the normal `create_*` / `delete_*` functions. The contract checks the approval list before each write and panics if the specific component was not approved.
+2. The trail owner reviews the proposal via Torii in `RemoteChangesPanel`, selects which items to include, and **publishes directly** using the normal `create_*` / `delete_*` functions (owner bypasses the approval gate).
+3. The owner calls `signal_review_result` which writes a lightweight `CollabReviewResult` model that the collaborator receives via Torii.
 
-This is Option B from the design document, extended with per-component-type approval lists instead of a flat `approved_insts[]` array. The extension was necessary because the owner must be able to say "I approve entity X's area and reactable but reject its description_text (the content is inappropriate)."
+Collaborators can **never** call `create_*` or `delete_*` directly on a trail they don't own — the gate is an unconditional `assert(false, NOT_APPROVED)`. This is simpler and cheaper than a two-phase commit design because it requires no intermediate approval storage.
 
 ---
 
 ## What was added to the contract
 
-### 1. `ApprovedProposal` model — `models/collab_proposal.cairo`
+### 1. `CollabReviewResult` model — `models/collab_proposal.cairo`
 
 ```cairo
 #[derive(Clone, Drop, Serde, Introspect)]
 #[dojo::model]
-pub struct ApprovedProposal {
-    #[key] pub trail_id: u128,
-    #[key] pub proposer: ContractAddress,
-    pub w_single_keys:       Array<felt252>,  // inst values for Entity, Area, Reactable, Exit, Hub, InventoryItem, Container, Trail, ParentToChildren, ChildToParent
-    pub w_description_texts: Array<felt252>,  // flat pairs: [inst, key_as_felt252, ...]
-    pub w_multi_keys:        Array<felt252>,  // flat pairs: [inst, key, ...] for Trigger, Condition, Effect, Action
-    pub d_single_keys:       Array<felt252>,
-    pub d_description_texts: Array<felt252>,
-    pub d_multi_keys:        Array<felt252>,
+pub struct CollabReviewResult {
+    #[key] pub trail_id:       u128,
+    #[key] pub proposer:       ContractAddress,
+    pub published_count:       u32,
+    pub skipped_count:         u32,
 }
 ```
 
-**Keys**: `(trail_id, proposer)` — one approval record per collaborator per trail. The owner overwrites the same slot each time they call `approve_proposal`, so there is at most one pending approval per collaborator at any moment.
+**Keys**: `(trail_id, proposer)` — one result record per collaborator per trail. Overwritten each time the owner calls `signal_review_result`.
 
-**Why 6 arrays instead of 30**: The critical ownership question is: can the trail owner approve structural components (area, reactable, exit) while independently rejecting textual content (description_text)? Three approval buckets per direction — single-key, description_texts, multi_keys — capture exactly that distinction while keeping storage cost minimal. A 30-array design (one per component type) would cost gas even on empty arrays; 6 arrays are always allocated, so the base cost is fixed and small regardless of what the collaborator proposed. Cross-entity granularity (e.g. approving ENTITY_A's area but not ENTITY_C's area) is expressed by which inst values appear inside the array.
+**Why a MODEL not an event**: Dojo events go to Torii's `event_messages` table and require a separate Torii subscription. A model arrives through the existing `subscribeEntityQuery` already set up in `dojo.ts`, integrating naturally with the `dojoSync` pipeline in `editor.data.ts`. No additional subscription wiring needed.
 
-**Per-component approval granularity — client vs contract**: The review UI lets the owner check or uncheck each individual component for each entity (Area, DescriptionText key 1, Action key 0, etc.). For `DescriptionText` and multi-key types (`Trigger`, `Condition`, `Effect`, `Action`), this per-item selection is enforced at the **contract level** via `contains_pair`. For single-key components (`Entity`, `Area`, `Reactable`, etc.), the contract uses a single flat `w_single_keys` list and cannot distinguish "approve Area but not Entity" for the same inst — if an inst is in `w_single_keys`, all single-key writes for that inst are permitted. This is enforced at the **client level** instead: `publishApproved`'s `buildFiltered` function only publishes the components that were actually checked by the owner, so the broader contract permission is never exploited.
+**Three-state notification** (client-side, driven by `published_count` and `skipped_count`):
+- `published_count > 0 && skipped_count == 0` → ✅ `toast.success("All your changes have been published.")`
+- `published_count > 0 && skipped_count > 0` → ⚠️ `toast.info("…but N item(s) were not included.")`
+- `published_count == 0` → ❌ rejection banner (staged changes preserved, collaborator can resubmit)
 
-**Who pays for this storage**: The trail owner, when calling `approve_proposal`. The storage cost is proportional to the number of inst/pair values stored (not the component data — just felt252 IDs). For typical approval sizes (tens of entities) this is negligible.
+---
 
-### 2. Single-key vs multi-key components
-
-Components fall into two categories:
-
-**Single-key** (`Entity`, `Reactable`, `Area`, `Exit`, `Hub`, `InventoryItem`, `Container`, `Trail`, `ParentToChildren`, `ChildToParent`): keyed only by `inst`. `w_single_keys` / `d_single_keys` store a flat list of `felt252` inst values. Membership is checked by `contains_inst`.
-
-**`DescriptionText`** (separate bucket): keyed by `(inst, u32 key)`. `w_description_texts` / `d_description_texts` store flat consecutive pairs `[inst1, key1_as_felt252, inst2, key2_as_felt252, ...]`. Kept in its own array so the owner can approve structural components while independently rejecting written text. Membership is checked by `contains_pair` with `o.key.into()` for the u32→felt252 conversion.
-
-**Multi-key** (`Trigger`, `Condition`, `Effect`, `Action`): keyed by `(inst, felt252 key)`. `w_multi_keys` / `d_multi_keys` store flat consecutive pairs `[inst1, key1, inst2, key2, ...]`. Membership is checked by `contains_pair`.
-
-```cairo
-// Approve description_text (ENTITY_C, key=1) and (ENTITY_A, key=2)
-approval.w_description_texts = array![ENTITY_C, 1, ENTITY_A, 2];
-
-// Inside create_description_text — per-item check
-assert(
-    contains_pair(approval.w_description_texts.span(), o.inst, o.key.into()),
-    Errors::NOT_APPROVED
-);
-
-// Approve area and reactable for ENTITY_A and ENTITY_C (single-key, all go in w_single_keys)
-approval.w_single_keys = array![ENTITY_A, ENTITY_C];
-
-// Inside create_area — per-item check
-assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
-```
-
-The two helper functions live as public free functions in `collab_proposal.cairo` and are imported by `designer.cairo`:
-
-```cairo
-pub fn contains_inst(mut list: Span<felt252>, inst: felt252) -> bool { ... }
-pub fn contains_pair(mut list: Span<felt252>, inst: felt252, key: felt252) -> bool { ... }
-```
-
-### 3. `CollabProposalEvent` — `models/collab_proposal.cairo`
+### 2. `CollabProposalEvent` — `models/collab_proposal.cairo`
 
 ```cairo
 #[derive(Drop, Serde)]
@@ -124,13 +89,26 @@ pub struct CollabProposalEvent {
 }
 ```
 
-The 14 `deleted_*` arrays exist solely to carry the full deletion proposal to the review panel. The `ApprovedProposal` model does not need new fields for component deletions — the existing `d_single_keys` / `d_description_texts` / `d_multi_keys` buckets already gate every `delete_*` entrypoint. Splitting deletions by component type in the event lets the owner see and approve/reject each deletion individually in the client UI without changing the contract approval model.
+The 14 `deleted_*` arrays carry per-component deletion proposals so the review panel can show the owner exactly which individual components are being removed.
 
-**Why an event, not a model**: A Dojo `event` writes nothing to World contract storage. The data is serialized into the transaction receipt, and Torii picks it up and stores it in its own off-chain database. Until the owner approves and the collaborator publishes, **zero entity or component data exists on-chain**. Nothing enters the game world during the review phase.
+**Why an event, not a model**: A Dojo `event` writes nothing to World contract storage. The data is serialized into the transaction receipt, and Torii picks it up and stores it in its own off-chain database. Until the owner publishes, **zero entity or component data exists on-chain**.
 
 `historical: false` means Torii retains only the **latest submission per (trail_id, proposer) pair**. If the collaborator revises their proposal and resubmits, the old one is replaced in Torii automatically.
 
-### 4. Three new system functions — `systems/designer.cairo`
+**Entity-level deletions**: `deleted_entity_insts` can only be proposed by trail owners and admins. `submit_for_review` enforces this:
+
+```cairo
+assert(
+    is_trail_owner || is_admin || deleted_entity_insts.len() == 0,
+    Errors::NOT_TRAIL_OWNER
+);
+```
+
+Collaborators may propose component-level deletions but cannot propose deleting the entity itself.
+
+---
+
+### 3. Two system functions — `systems/designer.cairo`
 
 #### `submit_for_review`
 
@@ -142,82 +120,57 @@ Cost:   collaborator pays (event-only transaction, cheap)
 
 Checks that the caller has been granted access to the specified trail (`has_role(trail_id.into(), caller)`) or is the trail owner or an admin. Panics with `NOT_COLLABORATOR` otherwise.
 
-After the check, calls `world.emit_event(@CollabProposalEvent { ... })`. Nothing is written to storage. The call accepts all 30 arrays: the 16 write arrays (entities, components, relationships), one entity-level deletion array, nine single-key component deletion arrays, and four multi-key component deletion arrays (flat `[inst, key, ...]` pairs).
+After the check, calls `world.emit_event(@CollabProposalEvent { ... })`. Nothing is written to storage. The call accepts all 30 arrays: the 16 write arrays (entities, components, relationships), one entity-level deletion array, nine single-key component deletion arrays, and four multi-key component deletion arrays.
 
 Trail owners see the "Submit for review" button in the staging panel as disabled with a tooltip — they publish directly and never need to submit for review.
 
-#### `approve_proposal`
+#### `signal_review_result`
 
 ```
 Caller: trail owner or admin
-Effect: writes ApprovedProposal model to World storage
-Cost:   trail owner pays (lightweight — inst IDs only, no component data)
+Effect: writes CollabReviewResult model to World storage
+Cost:   trail owner pays (trivial — 2 u32 fields + keys)
 ```
 
-The caller constructs the full `ApprovedProposal` struct specifying exactly which component types and which specific insts/pairs are approved. The contract validates trail ownership and writes the struct directly. The owner has full flexibility: approve all, approve a subset, or call with all-empty arrays to record a "nothing approved" state.
+Called by the owner after publishing (or deciding to skip entirely). Writes the `CollabReviewResult` model with the counts of published vs skipped items. The collaborator receives this via the existing entity subscription in Torii.
 
 ```cairo
-fn approve_proposal(ref self: ContractState, proposal: ApprovedProposal) {
+fn signal_review_result(
+    ref self: ContractState,
+    trail_id:        u128,
+    proposer:        ContractAddress,
+    published_count: u32,
+    skipped_count:   u32,
+) {
     let caller = starknet::get_caller_address();
-    assert(self.is_admin(caller) || world.is_owner_of_trail(proposal.trail_id, caller),
-           Errors::NOT_TRAIL_OWNER);
-    world.write_model(@proposal);
+    assert(
+        self.is_admin(caller) || world.is_owner_of_trail(trail_id, caller),
+        Errors::NOT_TRAIL_OWNER
+    );
+    world.write_model(@CollabReviewResult { trail_id, proposer, published_count, skipped_count });
 }
 ```
 
-#### `reject_proposal`
+---
 
-```
-Caller: trail owner or admin
-Effect: erases the ApprovedProposal model from storage
-Cost:   trail owner pays (trivial — erase one model)
-```
+### 4. Simplified approval gate on every write and delete function
 
-Removes the `ApprovedProposal` for the given `(trail_id, proposer)` pair. The collaborator's submitted event remains in Torii (as a historical record) but the on-chain gate is cleared. The collaborator cannot publish any component after a rejection.
-
-### 5. Approval gate on every write and delete function
-
-Every `create_*` and `delete_*` function in `designer.cairo` gained an inline approval gate. The gate fires only when **all three conditions are true**:
+Every `create_*` and `delete_*` function in `designer.cairo` has an inline gate. The gate fires only when **all three conditions are true**:
 
 ```cairo
 if !owned.is_zero()                                 // (1) caller is not an admin
    && trail_id.is_non_zero()                        // (2) entity belongs to a trail
    && !world.is_owner_of_trail(trail_id, owned)     // (3) caller does not own the trail
 {
-    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-    assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
+    assert(false, Errors::NOT_APPROVED);  // collaborators can never write directly
 }
 ```
 
 - Condition (1): `owned` is the return value of `_assert_caller_is_editor()`, which returns `0x0` for admins and `caller_address` for everyone else. Admins bypass the gate entirely.
-- Condition (2): entities without a trail (trail_id = 0) are core world entities; collaborators cannot touch those at all (earlier checks prevent it).
-- Condition (3): the trail owner writes freely — no approval needed on their own trail.
+- Condition (2): entities without a trail (`trail_id = 0`) are core world entities; collaborators cannot touch those at all.
+- Condition (3): the trail owner writes freely — no gate on their own trail.
 
-For `DescriptionText`, `contains_pair` is used with the `u32` key cast to `felt252`:
-
-```cairo
-// create_description_text
-assert(
-    contains_pair(approval.w_description_texts.span(), o.inst, o.key.into()),
-    Errors::NOT_APPROVED
-);
-```
-
-For `Trigger` / `Condition` / `Effect` / `Action`, `contains_pair` is used with the native `felt252` key:
-
-```cairo
-// create_trigger / create_condition / etc.
-assert(
-    contains_pair(approval.w_multi_keys.span(), o.inst, o.key),
-    Errors::NOT_APPROVED
-);
-```
-
-The gate applies to both write (`create_*`) and delete (`delete_*`) paths, using `w_single_keys` / `w_description_texts` / `w_multi_keys` for writes and the corresponding `d_*` arrays for deletes.
-
-**Important for new entities**: when a collaborator calls `create_entity`, the entity does not yet exist in storage. The gate uses `o.trail_id` (the field the collaborator sets on the struct) rather than `world.get_entity_trail_id(o.inst)` (which would return 0). The collaborator must set the correct `trail_id` on the entity, and that trail_id must appear in the `ApprovedProposal` for the gate to pass.
-
-For component writes after `create_entity`, the entity exists in storage, so `world.get_entity_trail_id(o.inst)` returns the real trail_id and the gate works normally.
+The gate is unconditional — there is no approval list to consult. If you are a non-owner collaborator, the call panics. The owner must be the one calling `create_*` / `delete_*` to publish proposal content.
 
 ---
 
@@ -236,23 +189,24 @@ grant_access_to_trail()   ────────►  RECIPIENT gets:
                                      submit_for_review(trail_id, ...) ──► CollabProposalEvent emitted
                                                                           (Torii receives it, no models written)
 
-[Torii delivers event]
+[Torii delivers CollabProposalEvent]
 [review panel shows diff]
+[owner selects items to publish]
 
-approve_proposal(proposal) ────────────────────────────────────────────► ApprovedProposal model written
- where proposal.w_single_keys = [ENTITY_C, ENTITY_A, ENTITY_C]          (trail_id, proposer) key
-       proposal.w_description_texts = [ENTITY_C, 1]                     cheap: inst IDs only
-       proposal.d_single_keys = []  (entity_B deletion rejected)
+create_entity([entity_C]) ─────────────────────────────────────────────► entity_C written
+ (passes creator_address=RECIPIENT)                                        creator_address = RECIPIENT ✓
+create_area([area_A_modified])  ────────────────────────────────────────► area_A written
+create_area([area_C])     ─────────────────────────────────────────────► area_C written
+ (entity_B deletion was deselected by owner — skipped)
 
-[Torii delivers ApprovedProposal]
-                                     create_area([area_A_modified])  ──► gate checks w_single_keys → ENTITY_A in list → OK
-                                     create_entity([entity_C])        ──► gate checks w_single_keys → ENTITY_C in list → OK
-                                     create_area([area_C])            ──► gate checks w_single_keys → ENTITY_C in list → OK
-                                     create_desc_text([desc_C])       ──► gate checks w_description_texts → (ENTITY_C,1) pair in list → OK
-                                     delete_entity([entity_B])        ──► gate checks d_single_keys → ENTITY_B NOT in list → PANIC
+signal_review_result(     ─────────────────────────────────────────────► CollabReviewResult written
+  trail_id, RECIPIENT,                                                     { published_count: 3,
+  published_count=3,                                                         skipped_count: 1 }
+  skipped_count=1)
+
+[Torii delivers CollabReviewResult]
+                                     ⚠️ toast.info("3 published, 1 skipped")
 ```
-
-The collaborator can publish the approved components in any order. The `ApprovedProposal` model remains in storage until the owner calls `reject_proposal` (which erases it) or overwrites it with a new `approve_proposal` call.
 
 ---
 
@@ -262,11 +216,10 @@ The collaborator can publish the approved components in any order. The `Approved
 |---|---|---|---|
 | `grant_access_to_trail` | Trail owner | Role grant (small) | Trail owner — one-time per collaborator |
 | `submit_for_review` | Collaborator | None (event only) | Collaborator — cheap; cost scales with calldata size |
-| `approve_proposal` | Trail owner | `ApprovedProposal` (inst IDs only) | Trail owner — cheap; cost scales with number of approved insts |
-| `reject_proposal` | Trail owner | Erases `ApprovedProposal` | Trail owner — trivial |
-| `create_*` / `delete_*` (publish) | Collaborator | Full component models | Collaborator — normal write cost, same as any publisher |
+| `create_*` / `delete_*` (publish) | Trail owner | Full component models | Trail owner — normal write cost |
+| `signal_review_result` | Trail owner | `CollabReviewResult` (2 u32 fields) | Trail owner — trivial |
 
-The design is intentional: the collaborator pays for their own content. The trail owner only pays for the lightweight approval record, not for the actual entity/component data.
+The collaborator pays only for their cheap proposal submission. The trail owner pays for the actual content writes.
 
 ---
 
@@ -290,15 +243,13 @@ let has_trail_role = o.trail_id.is_non_zero()
 assert(owned.is_zero() || is_owner_of_trail || has_trail_role, NOT_YOUR_TRAIL);
 ```
 
-`grant_access_to_trail` also grants the `trail_id.into()` role to the invitee, so `has_trail_role` is true for collaborators. This check prevents an editor from writing into a trail they were never invited to.
+`grant_access_to_trail` also grants the `trail_id.into()` role to the invitee, so `has_trail_role` is true for collaborators. This prevents an editor from writing into a trail they were never invited to.
 
 For component functions (`create_area`, etc.), `_assert_can_edit_entity` performs an equivalent check using `world.can_edit_trail(inst, owned)` or `has_role(trail_id.into(), owned)`.
 
-### Layer 3 — Approval gate (collab-specific)
+### Layer 3 — Unconditional collaborator gate
 
-After passing layers 1 and 2, the inline approval gate fires for any caller who is not the trail owner and not an admin. Without a valid `ApprovedProposal` containing the specific inst/pair, the transaction panics with `NOT_APPROVED`.
-
-This is the layer that enforces the two-phase commit. No amount of role-granting bypasses it — only an `ApprovedProposal` model written by the trail owner or an admin does.
+After passing layers 1 and 2, any caller who is not the trail owner and not an admin triggers `assert(false, NOT_APPROVED)`. No role assignment bypasses this — only being the trail owner or admin allows direct writes. Collaborators must always go through `submit_for_review`.
 
 ---
 
@@ -306,23 +257,29 @@ This is the layer that enforces the two-phase commit. No amount of role-granting
 
 ### Proposal review panel (`RemoteChangesPanel.tsx`)
 
-The `ProposalCard` component presents each pending proposal with per-component approval checkboxes:
+The `ProposalCard` component presents each pending proposal with per-component selection:
 
 - **Entity header**: a tri-state checkbox (checked / indeterminate / unchecked) selects or deselects all components for that entity at once.
-- **Expanded view**: each component gets its own row — `Area`, `DescriptionText · key 1`, `Action · key 0`, etc. — with a checkbox and a field-level diff (old value → new value, or green "new" for additions). Deselected rows are dimmed but remain visible so the owner can see what they are rejecting.
-- **Component deletion rows**: each deleted component appears as a red strikethrough row within the same expanded view. Multi-key deletions (e.g. `− DescriptionText · key 2`) each get their own checkbox.
+- **Expanded view**: each component gets its own row — `Area`, `DescriptionText · key 1`, `Action · key 0`, etc. — with a checkbox and a field-level diff (old value → new value, or green "new" for additions). Deselected rows are dimmed but remain visible so the owner can see what they are skipping.
+- **Component deletion rows**: each deleted component appears as a red strikethrough row within the same expanded view.
 - **Entity-level deletions** (`deleted_entity_insts`) are listed in a separate "Deletions" section below the entity rows.
-- **Approve button**: labelled "Approve (N)" where N is the count of currently selected component items. Disabled when nothing is selected.
+- **Publish button**: labelled "Publish selected (N)" where N is the count of currently selected items. Disabled when nothing is selected.
 
-`buildApprovedProposal` constructs the `ApprovedProposal` from the selection:
-- `w_single_keys`: insts that have at least one checked single-key component.
-- `w_description_texts` / `w_multi_keys`: flat `[inst, key, ...]` pairs for every checked DescriptionText / multi-key item.
-- `d_single_keys` / `d_description_texts` / `d_multi_keys`: same pattern for checked deletion items.
+**Selection key format** used by `buildSelectableKeys` and `publishFromProposal`:
+- `w:${inst}:${comp}` — write a single-key component
+- `w:${inst}:${comp}:${key}` — write a multi-key component (DescriptionText, Trigger, etc.)
+- `d:${inst}:${comp}` — delete a single-key component
+- `d:${inst}:${comp}:${key}` — delete a multi-key component
+
+`publishFromProposal(proposal, selected)` takes the `CollabProposalEvent` and the `Set<string>` of selected keys, publishes only the selected items (calling `create_*` / `delete_*` as the owner), and returns `{ publishedCount, skippedCount }`. The owner then calls `signalReviewResult(trailId, proposer, publishedCount, skippedCount)`.
+
+**`creator_address` for new entities**: `publishFromProposal` passes `proposer` as the `creatorAddress` argument when calling `publishEntity` for entities that do not yet exist in the world. The `publishEntity` function sets this as `creator_address` in the entity struct, and the contract uses it (non-zero check).
 
 ### Staging panel (`StagingPanel.tsx`)
 
-- **Component labels**: both unstaged and staged rows show the component name(s) being changed. Multi-key components include the key value (e.g. `DescriptionText (key 1)`, `Action (key 0)`).
-- **Submit for review**: disabled for trail owners (who publish directly) with a tooltip explaining why. Collaborators who do not own the trail see it as active whenever there are staged changes.
+- **Submit for review**: disabled for trail owners (who publish directly) with a tooltip explaining why. Collaborators see it as active whenever there are staged changes.
+- **Three-state notification**: watches `reviewResult` from `EditorData`; fires a toast or sets the rejection banner based on `published_count` / `skipped_count`.
+- **Rejection banner**: shown when `published_count === 0`; auto-dismissed when staged changes are cleared; has a manual Dismiss button.
 
 ---
 
@@ -330,11 +287,14 @@ The `ProposalCard` component presents each pending proposal with per-component a
 
 | File | Role |
 |---|---|
-| `packages/contracts/src/models/collab_proposal.cairo` | `ApprovedProposal` model, `CollabProposalEvent` event (30 arrays), `contains_inst`, `contains_pair` |
-| `packages/contracts/src/systems/designer.cairo` | `submit_for_review` (30 params), `approve_proposal`, `reject_proposal`, approval gates on all write/delete functions |
-| `packages/contracts/src/tests/collab_proposal_test.cairo` | Full flow tests covering approval, rejection, and access control |
-| `packages/contracts/src/tests/helpers.cairo` | `m_ApprovedProposal` and `e_CollabProposalEvent` registered in `namespace_def()` |
-| `packages/contracts/src/lib.cairo` | `collab_proposal` module declared under `models` and `tests` |
-| `packages/client/src/editor/components/RemoteChangesPanel.tsx` | Per-component proposal review UI, `buildInstMap`, `buildApprovedProposal`, `buildSelectableKeys` |
-| `packages/client/src/editor/components/StagingPanel.tsx` | Staging/unstaging UI, `Submit for review` (disabled for owners), component label with key display |
-| `packages/client/src/editor/publisher.ts` | `submitForReview` (serializes all 30 arrays), `publishApproved` with `buildFiltered` per-component enforcement |
+| `packages/contracts/src/models/collab_proposal.cairo` | `CollabReviewResult` model, `CollabProposalEvent` event (30 arrays) |
+| `packages/contracts/src/systems/designer.cairo` | `submit_for_review` (30 params), `signal_review_result`, unconditional `NOT_APPROVED` gate on all write/delete functions |
+| `packages/contracts/src/tests/collab_proposal_test.cairo` | Full flow tests covering owner publishes, partial publish, rejection, and access control |
+| `packages/contracts/src/tests/helpers.cairo` | `m_CollabReviewResult` and `e_CollabProposalEvent` registered in `namespace_def()` |
+| `packages/client/src/lib/dojo_bindings/typescript/models.gen.ts` | `CollabReviewResult` TypeScript interface and schema |
+| `packages/client/src/lib/dojo_bindings/typescript/contracts.gen.ts` | `signalReviewResult` / `buildSignalReviewResultCalldata` entrypoints |
+| `packages/client/src/editor/components/RemoteChangesPanel.tsx` | Per-component proposal review UI, `buildSelectableKeys`, `handlePublish` → `publishFromProposal` + `signalReviewResult` |
+| `packages/client/src/editor/components/StagingPanel.tsx` | Staging/unstaging UI, `Submit for review` (disabled for owners), three-state `reviewResult` notification |
+| `packages/client/src/editor/publisher.ts` | `submitForReview` (serializes all 30 arrays), `publishFromProposal` (owner publishes selected items), `signalReviewResult` re-export |
+| `packages/client/src/editor/data/editor.data.ts` | `reviewResult` state, `dojoSync` integration for `CollabReviewResult` |
+| `packages/client/src/lib/stores/wallet.store.ts` | Cartridge Controller policies: `submit_for_review`, `signal_review_result` |

--- a/docs/Collaborative Feature/collab-proposals-flow.md
+++ b/docs/Collaborative Feature/collab-proposals-flow.md
@@ -1,10 +1,10 @@
-# Collaborative Trail Editing — Approval Flow Options
+# Collaborative Trail Editing — Proposal Flow Options
 
-Two design options for gating how collaborator changes reach the chain.
+Two design options were considered for gating how collaborator changes reach the chain. This document records both options and the implemented solution.
 
 ---
 
-## Option 1 — Client-side only (no contract changes) 
+## Option 1 — Client-side only (no contract changes)
 
 **DECIDED TO NOT IMPLEMENT**
 
@@ -36,39 +36,6 @@ sequenceDiagram
     end
 ```
 
-### What is on-chain during review
-
-```
-Timeline ─────────────────────────────────────────────────────────────────►
-
-  Player B publishes        Player A reviews          Player A acts
-        │                         │                        │
-        ▼                         ▼                        ▼
-  ┌───────────────────┐    ┌──────────────┐    Accept  → ┌─────────────────┐
-  │ B's entity data   │    │ B's entity   │               │ B's version     │
-  │ B's reactable     │───►│ + components │               │ stays on chain  │
-  │ B's description   │    │ live in game │               └─────────────────┘
-  │ B's area          │    └──────────────┘    Dismiss → ┌─────────────────┐
-  │ ALL ON CHAIN      │                                   │ A re-publishes  │
-  └───────────────────┘                                   │ every component │
-                                                          │ (or deletes all)│
-                                                          └─────────────────┘
-```
-
-### Contract changes required
-**None.**
-
-### Client changes required
-
-| Area | File(s) | Change |
-|---|---|---|
-| Before-state snapshot | `editor.data.ts` | Before applying a Torii collaborator update to `dataPool`, snapshot the FULL previous entity collection (entity + all components) from `syncPool` |
-| RemoteChangesPanel — Accept | `RemoteChangesPanel.tsx` | No-op (everything already on chain) |
-| RemoteChangesPanel — Dismiss (existing) | `RemoteChangesPanel.tsx` | Re-publish every component individually using old snapshots |
-| RemoteChangesPanel — Dismiss (new) | `RemoteChangesPanel.tsx` | Delete entity + all components individually |
-| Visual pending state | `HierarchyTree.tsx` | Badge on entities and components awaiting review |
-| Detect collaborator changes | `editor.data.ts` | Route Torii updates from collaborators into review queue per entity |
-
 ### Tradeoffs
 
 | | |
@@ -76,16 +43,15 @@ Timeline ───────────────────────�
 | ✅ Zero contract changes | |
 | ✅ Simpler proposal logic | |
 | ❌ All component data is **live in game** until Player A acts | |
-| ❌ Dismiss is expensive — one `create_*` or `delete_*` per component type per entity. 10 entities × 5 components = up to 50 transactions | |
+| ❌ Dismiss is expensive — one `create_*` or `delete_*` per component type per entity | |
 | ❌ Player A pays for all revert transactions | |
 | ❌ Player A must be online to revert; every hour offline = longer exposure of unapproved content | |
-| ❌ `creator_address` for new entities becomes Player B (correct, since B is the caller) | |
 
 ---
 
-## Option 2 — Full proposal event + two-phase commit (recommended)
+## Option 2 — Proposal event + owner publishes (implemented)
 
-Player B never writes any model data to the chain. They emit a single proposal event containing the full entity + component snapshot. Player A approves with a lightweight transaction. Player B then publishes the approved data and **pays for their own work**.
+Player B never writes any model data to the chain. They emit a single proposal event containing the full entity + component snapshot. The trail owner reviews the proposal and **publishes approved changes directly**, then signals the result to the collaborator.
 
 ### How Dojo events work
 
@@ -108,7 +74,7 @@ When `world.emit_event` is called:
 2. Torii watches every transaction, detects the event, deserializes it, and stores it in its own off-chain database
 3. Client apps query or subscribe to that data via the Torii SDK
 
-With `historical: false`, Torii keeps only the **latest emission per key combination** — if B resubmits a revised proposal it overwrites the previous one and Player A always sees the most current version.
+With `historical: false`, Torii keeps only the **latest emission per key combination** — if B resubmits a revised proposal it overwrites the previous one and the owner always sees the most current version.
 
 ### Where the data lives at each stage
 
@@ -121,22 +87,22 @@ B's browser          Transaction / Chain            Torii (off-chain index)     
                      with ALL entity +              queryable by (trail_id,
                      component data                 proposer) — latest only
 
-                     approve_proposal() tx    →     ApprovedProposal visible   →   ApprovedProposal written
-                                                    in Torii models                to World state
-                                                    (inst IDs only, no data)       (cheap, no entity data)
+                     Owner calls create_entity()  →                            →   Entity + components
+                     create_area() etc. directly                                   written to World state
+                     (owner is the caller)
 
-B reads approval     create_entity() +        →                               →    Entity + components
-from Torii,          create_reactable() + …                                        written to World state
-calls publish        delete_entity() for                                           ApprovedProposal consumed
-                     approved deletions
+                     signal_review_result() tx  →   CollabReviewResult visible  →  CollabReviewResult written
+                                                    in Torii models                to World state
+                                                    (lightweight: counts only)     (trail_id, proposer key)
 ```
 
 | Stage | Where entity + component data lives | World state |
 |---|---|---|
 | B staging locally | Browser `dataPool` only | Nothing |
 | After `submit_for_review` | `CollabProposalEvent` in Torii (event payload) | Nothing |
-| After `approve_proposal` | Event still in Torii + `ApprovedProposal` model | `ApprovedProposal` (inst IDs only) |
-| After B publishes | Entity + component models | Entity + components live |
+| During owner review | Event still in Torii | Nothing |
+| After owner publishes | Entity + component models | Entity + components live |
+| After `signal_review_result` | — | `CollabReviewResult` (counts only) |
 
 ### The full flow
 
@@ -156,21 +122,20 @@ sequenceDiagram
 
     Note over A: Review panel reconstructs full<br/>proposed diff from event data
 
-    alt Approve (all or per component)
-        A->>Chain: approve_proposal(ApprovedProposal{<br/>trail_id, proposer,<br/>w_single_keys[], w_description_texts[],<br/>w_multi_keys[], d_single_keys[], ...})
-        Note over Chain: ApprovedProposal model written<br/>(inst IDs only — lightweight)
-        Note over A: A pays — very cheap (small model write)
+    alt Publish (all or selected items)
+        Note over A: A selects which items to include<br/>(per-component granularity)
+        A->>Chain: create_entity(entities) +<br/>create_reactable() + create_area() + …<br/>delete_entity(deletions)
+        Note over Chain: A is the caller — no approval gate<br/>New entities get B's address as creator_address
+        Note over A: A pays for the actual writes
 
-        Chain-->>B: Torii delivers ApprovedProposal
+        A->>Chain: signal_review_result(trail_id, proposer,<br/>published_count, skipped_count)
+        Note over Chain: CollabReviewResult model written<br/>(trail_id, proposer key — lightweight)
 
-        B->>Chain: create_entity(approved entities) +<br/>create_reactable() + create_area() + …<br/>delete_entity(approved deletions)
-        Note over Chain: Contract checks ApprovedProposal<br/>for each inst before writing.<br/>Approval consumed (erased) after publish.
-        Note over B: B pays — heavier (actual writes)
-
-    else Reject
-        A->>Chain: reject_proposal(trail_id, proposer)
-        Note over A: A pays — trivial (erase model or emit event)
-        Note over B: Nothing published. Chain unchanged.<br/>No revert needed.
+        Chain-->>B: Torii delivers CollabReviewResult
+        Note over B: Toast notification:<br/>✅ all published / ⚠️ partial / ❌ rejected
+    else Reject (publish nothing)
+        A->>Chain: signal_review_result(trail_id, proposer, 0, total_count)
+        Note over B: Rejection banner shown<br/>Staged changes preserved — B can resubmit
     end
 ```
 
@@ -179,223 +144,114 @@ sequenceDiagram
 ```
 Timeline ─────────────────────────────────────────────────────────────────►
 
-  B submits proposal      A reviews             A acts            B publishes
-        │                     │                   │                    │
-        ▼                     ▼                   ▼                    ▼
-  ┌───────────────┐    ┌────────────┐   Approve → ┌──────────┐  ┌────────────────┐
-  │ Proposal      │    │ Event data │              │ Approved │  │ Entity +       │
-  │ EVENT in      │───►│ in Torii   │              │ Proposal │  │ components     │
-  │ Torii only    │    │            │              │ model    │  │ live in game   │
-  │               │    │ Game:      │   Reject  → ┌──────────┐  └────────────────┘
-  │ Game: clean   │    │ clean      │              │ Nothing. │
-  └───────────────┘    └────────────┘              │ No revert│
-                                                   └──────────┘
+  B submits proposal      A reviews             A publishes + signals
+        │                     │                        │
+        ▼                     ▼                        ▼
+  ┌───────────────┐    ┌────────────┐   Publish → ┌──────────────────────┐
+  │ Proposal      │    │ Event data │              │ Entity + components  │
+  │ EVENT in      │───►│ in Torii   │              │ live in game         │
+  │ Torii only    │    │            │              │ CollabReviewResult   │
+  │               │    │ Game:      │              │ signals outcome      │
+  │ Game: clean   │    │ clean      │              └──────────────────────┘
+  └───────────────┘    └────────────┘   Reject  → ┌──────────────────────┐
+                                                   │ Nothing published.   │
+                                                   │ CollabReviewResult   │
+                                                   │ (0, total) signals   │
+                                                   │ rejection.           │
+                                                   └──────────────────────┘
 ```
 
 ### How Player A knows something is pending
 
-A subscribes to `CollabProposalEvent` filtered by their owned `trail_id`s. The state is determined by combining the event and model:
+A subscribes to `CollabProposalEvent` filtered by their owned `trail_id`s. Events in Torii signal pending proposals; once the owner signals a result, the collaborator's `CollabReviewResult` model in Torii confirms the outcome.
 
-| `CollabProposalEvent` in Torii | `ApprovedProposal` model | State |
+| `CollabProposalEvent` in Torii | `CollabReviewResult` for proposer | State |
 |---|---|---|
-| Yes | No | **Pending** — A needs to review |
-| Yes | Yes | **Approved** — waiting for B to publish |
+| Yes | No (or stale) | **Pending** — A needs to review and publish |
+| Yes | Yes (recent) | **Handled** — result delivered to collaborator |
 | No | No | Idle — nothing pending |
 
 ### `creator_address` behavior
 
-Since B is the one calling `create_entity` during publish, `get_caller_address()` = B naturally:
+The **owner** is the one calling `create_entity` during publish, so `get_caller_address()` = A. The contract logic preserves the correct creator:
 
-| Entity type | `creator_address` | Correct? |
+| Entity type | `creator_address` on-chain | How |
 |---|---|---|
-| Modified (existed, created by A) | Preserved as Player A | ✅ |
-| New (proposed by B, approved by A, published by B) | Player B (B is the caller) | ✅ |
+| Modified (existed, created by A) | Preserved as Player A | Contract reads stored creator; ignores passed value |
+| New (proposed by B, published by A) | Player B | Owner passes B's address; contract uses it for new entities (non-zero check) |
 
-No extra contract logic needed — the two-phase commit resolves this for free.
+The owner passes `creator_address = proposer` for each new entity in the proposal. The contract checks: if the entity is new AND `creator_address.is_non_zero()`, use the passed value; if the entity already exists, always preserve the stored creator.
 
 ### Contract changes required
 
-**1 new event** (`historical: false` — latest proposal per collaborator per trail):
+**1 Dojo event** (carries the full proposal payload):
 
 ```cairo
 #[derive(Drop, Serde)]
 #[dojo::event(historical: false)]
 pub struct CollabProposalEvent {
-    #[key]
-    pub trail_id: u128,
-    #[key]
-    pub proposer: ContractAddress,
-    // entity base
-    pub entities:             Array<Entity>,
-    // components (empty arrays if no changes for that type)
-    pub reactables:           Array<Reactable>,
-    pub areas:                Array<Area>,
-    pub exits:                Array<Exit>,
-    pub hubs:                 Array<Hub>,
-    pub description_texts:    Array<DescriptionText>,
-    pub inventory_items:      Array<InventoryItem>,
-    pub containers:           Array<Container>,
-    pub trails:               Array<Trail>,
-    // multi-key components
-    pub triggers:             Array<Trigger>,
-    pub conditions:           Array<Condition>,
-    pub effects:              Array<Effect>,
-    pub actions:              Array<Action>,
-    // relationships
-    pub parents:              Array<ParentToChildren>,
-    pub children:             Array<ChildToParent>,
-    // entity-level deletions
-    pub deleted_entity_insts:          Array<felt252>,
-    // component-level deletions — single-key types (flat list of inst values)
-    pub deleted_reactable_insts:       Array<felt252>,
-    pub deleted_area_insts:            Array<felt252>,
-    pub deleted_exit_insts:            Array<felt252>,
-    pub deleted_container_insts:       Array<felt252>,
-    pub deleted_inventory_item_insts:  Array<felt252>,
-    pub deleted_hub_insts:             Array<felt252>,
-    pub deleted_trail_insts:           Array<felt252>,
-    pub deleted_parent_insts:          Array<felt252>,
-    pub deleted_child_insts:           Array<felt252>,
-    // component-level deletions — multi-key types (flat [inst, key, ...] pairs)
-    pub deleted_description_text_keys: Array<felt252>,
-    pub deleted_trigger_keys:          Array<felt252>,
-    pub deleted_condition_keys:        Array<felt252>,
-    pub deleted_effect_keys:           Array<felt252>,
-    pub deleted_action_keys:           Array<felt252>,
+    #[key] pub trail_id: u128,
+    #[key] pub proposer: ContractAddress,
+    // (30 arrays — entity + all component write/delete proposals)
+    ...
 }
 ```
 
-The 14 `deleted_*` arrays carry per-component deletion proposals so the review panel can show the owner exactly which individual components are being removed, enabling per-component accept/reject. The actual on-chain approval gate uses the existing `d_single_keys`, `d_description_texts`, and `d_multi_keys` arrays in `ApprovedProposal` — no new approval fields are needed.
-
-**1 new model** — the approval gate (inst IDs only, no entity data):
+**1 Dojo model** — the review result (lightweight, counts only):
 
 ```cairo
 #[derive(Clone, Drop, Serde, Introspect)]
 #[dojo::model]
-pub struct ApprovedProposal {
-    #[key]
-    pub trail_id: u128,
-    #[key]
-    pub proposer: ContractAddress,
-    pub w_single_keys:       Array<felt252>,  // inst values for all single-key component types
-    pub w_description_texts: Array<felt252>,  // flat pairs [inst, key_as_felt252, ...] for DescriptionText
-    pub w_multi_keys:        Array<felt252>,  // flat pairs [inst, key, ...] for Trigger/Condition/Effect/Action
-    pub d_single_keys:       Array<felt252>,
-    pub d_description_texts: Array<felt252>,
-    pub d_multi_keys:        Array<felt252>,
+pub struct CollabReviewResult {
+    #[key] pub trail_id:       u128,
+    #[key] pub proposer:       ContractAddress,
+    pub published_count:       u32,
+    pub skipped_count:         u32,
 }
 ```
 
-**3 new functions** in `designer.cairo`:
+**2 system functions** in `designer.cairo`:
 
 ```cairo
 // B emits proposal — no model writes, B pays cheap gas
 fn submit_for_review(ref self: ContractState, trail_id: u128, entities: Array<Entity>, ...)
 
-// A approves — writes ApprovedProposal, A pays cheap gas
-// The caller constructs the full ApprovedProposal struct and passes it directly
-fn approve_proposal(ref self: ContractState, proposal: ApprovedProposal)
-
-// A rejects — erases ApprovedProposal if it exists, trivial gas
-fn reject_proposal(ref self: ContractState, trail_id: u128, proposer: ContractAddress)
+// A signals result after publishing — writes CollabReviewResult
+fn signal_review_result(ref self: ContractState, trail_id: u128, proposer: ContractAddress,
+                        published_count: u32, skipped_count: u32)
 ```
 
-**Guard on every `create_*` and `delete_*` function** for collaborator callers:
+**Simplified gate on every `create_*` and `delete_*` function** for collaborator callers:
+
 ```cairo
 // fires when caller is not admin AND entity belongs to a trail AND caller is not trail owner
-let approval: ApprovedProposal = world.read_model((trail_id, owned));
-assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
-// DescriptionText uses contains_pair with w_description_texts; Trigger/etc. use w_multi_keys
+assert(false, Errors::NOT_APPROVED);  // collaborators can never write directly
 ```
 
 ### Client changes required
 
 | Area | File(s) | Change |
 |---|---|---|
-| Collaborator publish flow | `publisher.ts` | Replace all individual `create_*` / `delete_*` calls with a single `submit_for_review` call carrying all staged data and deletions |
-| Session policy | `wallet.store.ts` | Add `submit_for_review`, `create_entity`, `delete_entity` for collaborators; remove direct `create_reactable` etc. (components published as part of approval flow) |
-| Proposal subscription | `editor.data.ts` / new hook | Subscribe to `CollabProposalEvent` filtered by owned `trail_id`s |
-| Approval subscription | `editor.data.ts` / new hook | B subscribes to `ApprovedProposal` model for their `(trail_id, address)` — triggers publish flow |
-| Review panel | `RemoteChangesPanel.tsx` | Reconstruct full entity+component diff from event payload; **Approve** = `approve_proposal(insts[])`; **Reject** = `reject_proposal` |
-| Per-entity approval | `RemoteChangesPanel.tsx` | A can approve entity X but reject entity Y within the same proposal via `approved_insts[]` |
-| Track proposal state | `editor.data.ts` | Combine `CollabProposalEvent` presence + `ApprovedProposal` model to determine pending / approved / idle per collaborator |
+| Collaborator publish flow | `publisher.ts` | Replace individual `create_*` / `delete_*` calls with `submit_for_review` |
+| Owner review + publish | `RemoteChangesPanel.tsx` | Reconstruct diff from event payload; **Publish selected** = `publishFromProposal(proposal, selected)` + `signalReviewResult(...)` |
+| Result notification | `StagingPanel.tsx` | Watch `CollabReviewResult` via entity subscription; three-state toast / banner |
+| Session policy | `wallet.store.ts` | Add `submit_for_review`, `signal_review_result`; remove `approve_proposal`, `reject_proposal` |
 
 ### Who sees what — filtering proposals to trail owners
 
-Each player only sees proposals for trails **they own**. This is enforced at three independent layers:
+Each player only sees proposals for trails **they own**. Enforced at three independent layers:
 
 #### Layer 1 — Subscription filter (client)
 
-When the editor mounts, the owner queries `CollabProposalEvent` keyed by their own trail IDs. One query per owned trail; results are merged.
-
-```typescript
-// editor.data.ts or useCollabProposals() hook
-const subscribeToProposals = async () => {
-    const sdk = getDojoSdk();
-    const ownedTrailIds = TokenStore().ownedTrailIds; // e.g. [1n, 5n, 12n]
-
-    const queries = ownedTrailIds.map((trailId) =>
-        new ToriiQueryBuilder<SchemaType>()
-            .withLimit(100)
-            .includeHashedKeys()
-            .withClause(
-                new ClauseBuilder<SchemaType>().keys(
-                    ["lore-CollabProposalEvent"],
-                    [toHex(trailId), undefined], // trail_id = mine, any proposer
-                ).build()
-            )
-            .withEntityModels(["lore-CollabProposalEvent"])
-    );
-
-    const proposals = (await Promise.all(queries.map(q => sdk.getEventMessages({ query: q }))))
-        .flatMap(r => r?.getItems() ?? []);
-
-    set({ pendingProposals: proposals });
-};
-```
-
-Player A queries trail 1 → gets B's proposal only. Player D queries their trail → gets C's proposal only. Neither ever receives proposals for trails they don't own.
+Owner queries `CollabProposalEvent` keyed by their own trail IDs.
 
 #### Layer 2 — UI gate (client)
 
-`RemoteChangesPanel` double-filters as a safety net — even if a subscription leak occurs, only trail owners see the review UI:
+`RemoteChangesPanel` double-filters: only renders proposals where `trail_id ∈ ownedTrailIds`.
 
-```typescript
-// RemoteChangesPanel.tsx
-const { ownedTrailIds } = useOwnedTokenIds();
+#### Layer 3 — Contract enforcement
 
-const myProposals = pendingProposals.filter(p =>
-    ownedTrailIds.includes(BigInt(p.models?.lore?.CollabProposalEvent?.trail_id ?? 0))
-);
-
-if (myProposals.length === 0) return null;
-```
-
-#### Layer 3 — Contract enforcement (hard gate)
-
-`approve_proposal` asserts the caller is the trail owner before writing the `ApprovedProposal` model. Even if a client bug routed the wrong panel to the wrong player, the contract rejects the call:
-
-```cairo
-fn approve_proposal(
-    ref self: ContractState, trail_id: u128, proposer: ContractAddress,
-    approved_insts: Array<felt252>, approved_deletions: Array<felt252>
-) {
-    let caller = get_caller_address();
-    assert(
-        world.is_owner_of_trail(trail_id, caller) || self.is_admin(caller),
-        Errors::NOT_TRAIL_OWNER
-    );
-    // ...write ApprovedProposal
-}
-```
-
-#### Summary
-
-| Layer | Where | Enforcement |
-|---|---|---|
-| Subscription | `editor.data.ts` | Query `CollabProposalEvent` with `trail_id IN ownedTrailIds` |
-| UI | `RemoteChangesPanel.tsx` | Render only proposals where `trail_id ∈ ownedTrailIds` |
-| Contract | `approve_proposal` | Asserts `is_owner_of_trail(trail_id, caller)` — cannot be bypassed |
+`signal_review_result` asserts the caller is the trail owner. Direct `create_*` / `delete_*` calls by collaborators unconditionally panic with `NOT_APPROVED`.
 
 ---
 
@@ -406,29 +262,28 @@ fn approve_proposal(
 | ✅ Unapproved content — entity AND all components — **never reaches the chain or the game** | |
 | ✅ Reject is a no-op — no revert transactions needed | |
 | ✅ Full component data in event — A sees the complete proposed diff | |
-| ✅ B pays for their own work (the heavier publish transactions) | |
-| ✅ A pays only for the lightweight approval (small model write) | |
-| ✅ `creator_address` is correct for new entities naturally (B is the caller) | |
-| ✅ Per-component approval granularity — owner can approve/reject individual components (Area, DescriptionText, Action…) within each entity independently | |
+| ✅ A pays for the writes; B pays only for the cheap proposal event | |
+| ✅ `creator_address` correct for new entities — owner passes proposer's address | |
+| ✅ Per-component selection granularity — owner can publish/skip individual components | |
 | ✅ Audit trail in Torii via the proposal event | |
 | ✅ Trail owners only see proposals for their own trails (three-layer filter) | |
-| ❌ Contract changes required: 1 event + 1 model + 3 functions + guard in `create_entity` / `delete_entity` | |
+| ✅ No intermediate `ApprovedProposal` storage — simpler contract state | |
+| ❌ Contract changes required: 1 event + 1 model + 2 functions + gate on all `create_*`/`delete_*` | |
 | ❌ Large calldata when submitting many entities — may need batching for big changesets | |
-| ❌ Component-level functions (`create_reactable` etc.) still need guards if called directly — soft enforcement for now | |
 
 ---
 
 ## Side-by-side comparison
 
-| Dimension | Option 1 (client-only) | Option 2 (proposal + two-phase commit) |
+| Dimension | Option 1 (client-only) | Option 2 (proposal + owner publishes) |
 |---|---|---|
-| Contract changes | None | 1 event + 1 model (6-array) + 3 functions + guards on all create_*/delete_* |
+| Contract changes | None | 1 event + 1 model + 2 functions + simplified gate |
 | Unapproved content in game | **Yes — until A acts** | **Never** |
-| Who pays for writes | B (publish) + A (revert) | B (submit + publish), A (approve only) |
-| `creator_address` new entities | Player B ✅ | Player B ✅ |
-| Reject/dismiss cost | Many on-chain txs (one per component per entity) | Free — no-op |
+| Who pays for writes | B (publish) + A (revert) | A (publish), B (submit only) |
+| `creator_address` new entities | Player B ✅ | Player B ✅ (owner passes B's address) |
+| Reject/dismiss cost | Many on-chain txs | Free — just `signal_review_result(0, n)` |
 | Player A offline impact | B's content live in game | Nothing visible |
-| Per-component approval | No | Yes — each component of each entity can be independently approved or rejected |
+| Per-component selection | No | Yes — owner selects items in review UI |
 | Pending data storage | Not applicable (already on chain) | Torii event payload (off-chain index) |
-| Audit trail | Torii model history | Historical `CollabProposalEvent` |
-| Large changeset handling | No issue | May need client-side batching |
+| Intermediate approval state | None | None (owner publishes directly, no staging step) |
+| Collaborator notification | None | `CollabReviewResult` model via Torii entity subscription |

--- a/packages/client/src/editor/components/RemoteChangesPanel.tsx
+++ b/packages/client/src/editor/components/RemoteChangesPanel.tsx
@@ -4,11 +4,10 @@ import type { AnyObject } from "../lib/types";
 import type { BigNumberish } from "starknet";
 import { Button } from "./ui/Button";
 import { CollapsibleComponent } from "./CollapsibleComponent";
-import { SystemCalls } from "@lib/systemCalls";
 import { useTokenStore } from "@/lib/stores/token.store";
+import { publishFromProposal, signalReviewResult } from "@/editor/publisher";
 import type {
 	CollabProposalEvent,
-	ApprovedProposal,
 	DescriptionText,
 	Entity,
 } from "@/lib/dojo_bindings/typescript/models.gen";
@@ -334,73 +333,6 @@ const buildSelectableKeys = (
 	return keys;
 };
 
-/** Builds an ApprovedProposal limited to the selected component items. */
-const buildApprovedProposal = (
-	proposal: CollabProposalEvent,
-	selected: Set<string>,
-	instMap: Map<string, InstData>,
-): ApprovedProposal => {
-	const sel = (key: string) => selected.has(key);
-
-	// w_single_keys: insts with at least one selected single-key write component
-	const wSingleSet = new Set<string>();
-	for (const [inst, data] of instMap) {
-		if (SINGLE_WRITE_COMPS.some(c => data.components.includes(c) && sel(`w:${inst}:${c}`)))
-			wSingleSet.add(inst);
-	}
-
-	// w_description_texts: flat [inst, key, ...] pairs
-	const wDesc: BigNumberish[] = [];
-	for (const dt of proposal.description_texts) {
-		if (sel(`w:${dt.inst}:DescriptionText:${dt.key}`)) { wDesc.push(dt.inst); wDesc.push(dt.key ?? 0); }
-	}
-
-	// w_multi_keys: flat [inst, key, ...] pairs for Trigger/Condition/Effect/Action
-	const wMulti: BigNumberish[] = [];
-	for (const [comp, arr] of [
-		["Trigger", proposal.triggers], ["Condition", proposal.conditions],
-		["Effect", proposal.effects], ["Action", proposal.actions],
-	] as [string, { inst: unknown; key: unknown }[]][]) {
-		for (const c of arr) {
-			if (sel(`w:${c.inst}:${comp}:${c.key}`)) { wMulti.push(c.inst as BigNumberish); wMulti.push(c.key as BigNumberish); }
-		}
-	}
-
-	// d_single_keys: entity deletions + selected single-key component deletions
-	const dSingleSet = new Set<string>();
-	for (const inst of proposal.deleted_entity_insts)
-		if (sel(`d:${inst}:Entity`)) dSingleSet.add(String(inst));
-	for (const comp of ["Reactable","Area","Exit","Container","InventoryItem","Hub","Trail","ParentToChildren","ChildToParent"]) {
-		for (const inst of getDelSingleArr(proposal, comp))
-			if (sel(`d:${inst}:${comp}`)) dSingleSet.add(String(inst));
-	}
-
-	// d_description_texts: flat [inst, key, ...] pairs
-	const dDesc: BigNumberish[] = [];
-	const ddFlat = proposal.deleted_description_text_keys as BigNumberish[];
-	for (let i = 0; i + 1 < ddFlat.length; i += 2) {
-		if (sel(`d:${ddFlat[i]}:DescriptionText:${ddFlat[i + 1]}`)) { dDesc.push(ddFlat[i]); dDesc.push(ddFlat[i + 1]); }
-	}
-
-	// d_multi_keys: flat [inst, key, ...] pairs for Trigger/Condition/Effect/Action deletions
-	const dMulti: BigNumberish[] = [];
-	for (const comp of MULTI_WRITE_COMPS) {
-		const flat = getDelPairsForComp(proposal, comp);
-		for (let i = 0; i + 1 < flat.length; i += 2)
-			if (sel(`d:${flat[i]}:${comp}:${flat[i + 1]}`)) { dMulti.push(flat[i]); dMulti.push(flat[i + 1]); }
-	}
-
-	return {
-		trail_id: proposal.trail_id,
-		proposer: proposal.proposer,
-		w_single_keys: Array.from(wSingleSet) as unknown as bigint[],
-		w_description_texts: wDesc as unknown as bigint[],
-		w_multi_keys: wMulti as unknown as bigint[],
-		d_single_keys: Array.from(dSingleSet) as unknown as bigint[],
-		d_description_texts: dDesc as unknown as bigint[],
-		d_multi_keys: dMulti as unknown as bigint[],
-	};
-};
 
 // ---------------------------------------------------------------------------
 // ProposalCard
@@ -444,15 +376,15 @@ const ProposalCard = ({ proposal }: { proposal: CollabProposalEvent }) => {
 		});
 	};
 
-	const handleApprove = async () => {
+	const handlePublish = async () => {
 		if (selected.size === 0) return;
 		setBusy(true);
 		try {
-			const approval = buildApprovedProposal(proposal, selected, instMap);
-			await SystemCalls.approveProposal(approval);
+			const { publishedCount, skippedCount } = await publishFromProposal(proposal, selected);
+			await signalReviewResult(BigInt(proposal.trail_id), proposal.proposer, publishedCount, skippedCount);
 			removeSelf();
 		} catch (e) {
-			console.error("approveProposal failed:", e);
+			console.error("publishFromProposal failed:", e);
 		} finally {
 			setBusy(false);
 		}
@@ -461,10 +393,11 @@ const ProposalCard = ({ proposal }: { proposal: CollabProposalEvent }) => {
 	const handleReject = async () => {
 		setBusy(true);
 		try {
-			await SystemCalls.rejectProposal(BigInt(proposal.trail_id), proposal.proposer);
+			const totalKeys = buildSelectableKeys(proposal, instMap).size;
+			await signalReviewResult(BigInt(proposal.trail_id), proposal.proposer, 0, totalKeys);
 			removeSelf();
 		} catch (e) {
-			console.error("rejectProposal failed:", e);
+			console.error("signalReviewResult (reject) failed:", e);
 		} finally {
 			setBusy(false);
 		}
@@ -499,8 +432,8 @@ const ProposalCard = ({ proposal }: { proposal: CollabProposalEvent }) => {
 					<span className="font-mono text-xs">{shortAddr(proposal.proposer)}</span>
 				</div>
 				<div className="flex gap-1">
-					<Button size="sm" disabled={busy || selected.size === 0} onClick={handleApprove}>
-						Approve ({selected.size})
+					<Button size="sm" disabled={busy || selected.size === 0} onClick={handlePublish}>
+						Publish selected ({selected.size})
 					</Button>
 					<Button size="sm" variant="destructive" disabled={busy} onClick={handleReject}>
 						Reject

--- a/packages/client/src/editor/components/StagingPanel.tsx
+++ b/packages/client/src/editor/components/StagingPanel.tsx
@@ -1,13 +1,12 @@
-import { useMemo, useState, useEffect, useRef } from "react";
+import { useMemo, useState, useEffect } from "react";
 import EditorData, { useEditorData } from "../data/editor.data";
 import type { ChangeSet } from "../lib/types";
-import { publishConfigToContract, submitForReview, publishApproved } from "../publisher";
+import { publishConfigToContract, submitForReview } from "../publisher";
 import { Button } from "./ui/Button";
 import { CollapsibleComponent } from "./CollapsibleComponent";
 import { useWalletStore } from "@/lib/stores/wallet.store";
 import { useTokenStore } from "@/lib/stores/token.store";
 import EditorStore from "@/lib/stores/editor.store";
-import type { ApprovedProposal } from "@/lib/dojo_bindings/typescript/models.gen";
 import { toast } from "sonner";
 
 const entityLabel = (c: ChangeSet) =>
@@ -47,50 +46,6 @@ const RejectedBannerSection = ({ onDismiss }: { onDismiss: () => void }) => (
 	</section>
 );
 
-// ---------------------------------------------------------------------------
-// PublishApprovedSection — shown when the current user has approvals waiting
-// ---------------------------------------------------------------------------
-
-const PublishApprovedSection = ({
-	approvals,
-	busy,
-	onPublish,
-}: {
-	approvals: ApprovedProposal[];
-	busy: boolean;
-	onPublish: (approval: ApprovedProposal) => void;
-}) => {
-	if (approvals.length === 0) return null;
-
-	return (
-		<section className="flex flex-col gap-1">
-			<h4 className="font-semibold text-green-700">Approved by trail owner</h4>
-			{approvals.map((approval, i) => (
-				<div
-					key={i}
-					className="flex items-center justify-between gap-2 rounded border border-green-300 bg-green-50 px-2 py-1"
-				>
-					<div className="flex flex-col min-w-0">
-						<span className="font-mono text-[10px] truncate opacity-60">
-							{shortAddr(approval.proposer)}
-						</span>
-						<span className="text-[10px] opacity-50">
-							{(approval.w_single_keys as any[]).length} writes,{" "}
-							{(approval.d_single_keys as any[]).length} deletions
-						</span>
-					</div>
-					<Button
-						size="sm"
-						disabled={busy}
-						onClick={() => onPublish(approval)}
-					>
-						Publish approved
-					</Button>
-				</div>
-			))}
-		</section>
-	);
-};
 
 // ---------------------------------------------------------------------------
 // StagingPanel
@@ -106,12 +61,11 @@ const PublishApprovedSection = ({
  * a prior submission, "Publish approved" publishes those approved changes.
  */
 export const StagingPanel = () => {
-	const { changeSet, stagedChanges, activeTrailId, currentApprovals } = useEditorData();
+	const { changeSet, stagedChanges, activeTrailId, reviewResult } = useEditorData();
 	const { walletAddress } = useWalletStore();
 	const { ownedTrailIds } = useTokenStore();
 	const isAdmin = EditorStore().isAdmin ?? false;
 	const [reviewBusy, setReviewBusy] = useState(false);
-	const [publishBusy, setPublishBusy] = useState(false);
 	const [showRejectedBanner, setShowRejectedBanner] = useState(false);
 
 	// Trail owners and admins may publish directly. When a trail is active, collaborators
@@ -132,69 +86,28 @@ export const StagingPanel = () => {
 
 	const allCount = unstaged.length + staged.length;
 
-	// Approvals for the current user on the active trail
-	const norm = (addr: string) => addr.replace(/^0x0+/, "0x").toLowerCase();
-	const myApprovals = useMemo(() => {
-		if (!activeTrailId || !walletAddress) return [];
-		const myAddr = norm(walletAddress);
-		return currentApprovals.filter(
-			(a) =>
-				BigInt(a.trail_id) === activeTrailId &&
-				norm(a.proposer) === myAddr
-		);
-	}, [currentApprovals, activeTrailId, walletAddress]);
-
-	// Detect when the trail owner acts on the collaborator's proposal.
-	// justPublishedRef guards against a false positive: if WE cleared the approval (by publishing),
-	// that drop must not trigger the rejection banner.
-	const prevMyApprovalsRef = useRef<ApprovedProposal[]>([]);
-	const justPublishedRef = useRef(false);
+	// Show notification when the trail owner signals review result for this collaborator.
 	useEffect(() => {
-		const prev = prevMyApprovalsRef.current;
-		prevMyApprovalsRef.current = myApprovals;
-		const hadApproval = prev.length > 0;
-		const hasApproval = myApprovals.length > 0;
-
-		// Rejection: approval dropped while staged changes remain.
-		if (hadApproval && !hasApproval && staged.length > 0) {
-			if (justPublishedRef.current) {
-				justPublishedRef.current = false;
-				return;
-			}
+		if (!reviewResult || !walletAddress || !activeTrailId) return;
+		if (BigInt(reviewResult.trail_id) !== activeTrailId) return;
+		const norm = (a: string) => a.replace(/^0x0+/, "0x").toLowerCase();
+		if (norm(reviewResult.proposer) !== norm(walletAddress)) return;
+		if (reviewResult.skipped_count === 0 && reviewResult.published_count > 0) {
+			toast.success("All your changes have been published.");
+		} else if (reviewResult.published_count > 0) {
+			toast.info(
+				`Your changes were published, but ${reviewResult.skipped_count} item(s) were not included.`,
+				{ duration: 12000, dismissible: true },
+			);
+		} else {
 			setShowRejectedBanner(true);
 		}
-	}, [myApprovals]);
+	}, [reviewResult]);
 
 	// Auto-dismiss the rejected banner once the collaborator clears their staged changes.
 	useEffect(() => {
 		if (staged.length === 0) setShowRejectedBanner(false);
 	}, [staged.length]);
-
-	const handlePublish = async (approval: ApprovedProposal) => {
-		if (!activeTrailId) return;
-		setPublishBusy(true);
-		justPublishedRef.current = true;
-		try {
-			await publishApproved(activeTrailId, approval);
-			// After publishing, check if any staged items for this trail remain.
-			// If so, they were not included in the approval — tell the collaborator.
-			const remaining = EditorData().get().stagedChanges.filter((c) => {
-				const entity = EditorData().getEntity(c.inst);
-				return BigInt(entity?.Entity?.trail_id?.toString() ?? "0") === activeTrailId;
-			});
-			if (remaining.length > 0) {
-				toast.info(
-					`${remaining.length} staged item${remaining.length !== 1 ? "s" : ""} were not included in the approval — resubmit for review.`,
-					{ duration: 12000, dismissible: true },
-				);
-			}
-		} catch (e) {
-			justPublishedRef.current = false;
-			console.error("publishApproved failed:", e);
-		} finally {
-			setPublishBusy(false);
-		}
-	};
 
 	const handleSubmitForReview = async () => {
 		if (!activeTrailId) return;
@@ -293,14 +206,6 @@ export const StagingPanel = () => {
 
 				{showRejectedBanner && staged.length > 0 && (
 					<RejectedBannerSection onDismiss={() => setShowRejectedBanner(false)} />
-				)}
-
-				{myApprovals.length > 0 && activeTrailId !== undefined && (
-					<PublishApprovedSection
-						approvals={myApprovals}
-						busy={publishBusy}
-						onPublish={handlePublish}
-					/>
 				)}
 
 				{allCount > 0 && (

--- a/packages/client/src/editor/data/editor.data.ts
+++ b/packages/client/src/editor/data/editor.data.ts
@@ -15,7 +15,7 @@ import type {
 	DescriptionText,
 	ComponentTypeEnum,
 	CollabProposalEvent,
-	ApprovedProposal,
+	CollabReviewResult,
 } from "@/lib/dojo_bindings/typescript/models.gen";
 import { StoreBuilder } from "@/lib/utils/storebuilder";
 import {
@@ -69,7 +69,7 @@ const {
 	editorInitialized: false,
 	// Collab proposal state
 	pendingProposals: [] as CollabProposalEvent[],
-	currentApprovals: [] as ApprovedProposal[],
+	reviewResult: undefined as CollabReviewResult | undefined,
 });
 
 const getItem = (id: BigNumberish, syncPool = false) => {
@@ -972,25 +972,11 @@ const dojoSync = (
 	obj: AnyObject,
 	{ verbose = false }: { verbose?: boolean; sync?: boolean } = {},
 ) => {
-	// ApprovedProposal arrives via the regular entity subscription — store it separately
-	// rather than merging it into the entity pool.
-	const approvedProposal = (obj as any).ApprovedProposal as ApprovedProposal | undefined;
-	if (approvedProposal?.trail_id !== undefined) {
-		const norm = (addr: string) => addr.replace(/^0x0+/, "0x").toLowerCase();
-		const filtered = get().currentApprovals.filter(
-			(a) =>
-				!(BigInt(a.trail_id) === BigInt(approvedProposal.trail_id) &&
-					norm(a.proposer) === norm(approvedProposal.proposer))
-		);
-		// When the owner rejects, the contract erases the model — Torii sends it back with
-		// all array fields empty. Don't re-add the empty shell; just remove the old entry so
-		// the collaborator's rejection-notification effect fires correctly.
-		const isEmpty =
-			(approvedProposal.w_single_keys as any[]).length === 0 &&
-			(approvedProposal.w_description_texts as any[]).length === 0 &&
-			(approvedProposal.w_multi_keys as any[]).length === 0 &&
-			(approvedProposal.d_single_keys as any[]).length === 0;
-		set({ currentApprovals: isEmpty ? filtered : [...filtered, approvedProposal] });
+	// CollabReviewResult arrives via the regular entity subscription — store it so the
+	// collaborator's StagingPanel can show the appropriate notification.
+	const reviewResult = (obj as any).CollabReviewResult as CollabReviewResult | undefined;
+	if (reviewResult?.trail_id !== undefined) {
+		set({ reviewResult });
 		return;
 	}
 
@@ -1216,14 +1202,6 @@ export const syncProposals = async (ownedTrailIds: bigint[]): Promise<void> => {
 		console.error("Error fetching collab proposals from Torii:", error);
 		throw error;
 	}
-};
-
-export const getApprovalForTrail = (trailId: bigint, proposerAddress: string): ApprovedProposal | undefined => {
-	const norm = (addr: string) => addr.replace(/^0x0+/, "0x").toLowerCase();
-	const target = norm(proposerAddress);
-	return get().currentApprovals.find(
-		(a) => BigInt(a.trail_id) === trailId && norm(a.proposer) === target
-	);
 };
 
 export const propertiesRegistered = async (
@@ -1901,7 +1879,6 @@ const EditorData = createFactory({
 	simulateRemoteEntityEdit,
 	// Collab proposals
 	syncProposals,
-	getApprovalForTrail,
 });
 
 export default EditorData;

--- a/packages/client/src/editor/publisher.ts
+++ b/packages/client/src/editor/publisher.ts
@@ -26,7 +26,7 @@ import {
 	type ParentToChildren,
 	type Hub,
 	type Trail,
-	type ApprovedProposal,
+	type CollabProposalEvent,
 } from "@/lib/dojo_bindings/typescript/models.gen";
 import { tick } from "@/lib/utils/utils";
 import { toCairoArray } from "@/editor/editor.utils";
@@ -249,13 +249,13 @@ const publishEntityRelationships = async (collection: EntityCollection) => {
 	}
 };
 
-const publishEntity = async (entity: Entity) => {
+const publishEntity = async (entity: Entity, creatorAddress?: bigint) => {
 	const entityData = [
 		num.toBigInt(entity.inst.toString()),
 		entity.is_entity,
 		num.toBigInt(entity.trail_id?.toString() ?? "0"),
 		byteArray.byteArrayFromString(entity.name),
-		0n, // creator_address is managed on contract level
+		creatorAddress ?? 0n, // pass non-zero to attribute entity to collaborator
 		entity.alt_names.length > 0
 			? entity.alt_names
 				.filter((x) => x.length > 0)
@@ -638,15 +638,15 @@ const publishRegisterPropertyRegistry = async () => {
 		await dispatchDesignerCall("register_property_registry", [done]);
 };
 
-// ─── Collab: submit for review / publish approved ─────────────────────────────
+// ─── Collab: submit for review / publish from proposal ────────────────────────
 
 // Build helpers — mirror the per-type serialization in the publish* functions above
 // but return the raw data array instead of dispatching a call.
 
-const buildEntityData = (e: Entity) => [
+const buildEntityData = (e: Entity, creatorAddress?: bigint) => [
 	num.toBigInt(e.inst.toString()), e.is_entity,
 	num.toBigInt(e.trail_id?.toString() ?? "0"),
-	byteArray.byteArrayFromString(e.name), 0n,
+	byteArray.byteArrayFromString(e.name), creatorAddress ?? 0n,
 	e.alt_names.length > 0 ? e.alt_names.filter(x => x.length > 0).map(x => byteArray.byteArrayFromString(x)) : 0,
 	e.actions_keys.length > 0 ? e.actions_keys.filter(x => x !== num.toBigInt(0)).map(x => num.toBigInt(x.toString())) : 0,
 ];
@@ -751,22 +751,6 @@ const buildParentToChildrenData = (p: ParentToChildren) => [
 const buildChildToParentData = (c: ChildToParent) => [
 	num.toBigInt(c.inst.toString()), c.is_child, num.toBigInt(c.parent),
 ];
-
-// felt252 list membership checks — mirror contains_inst / contains_pair from the Cairo contract.
-const containsInst = (list: bigint[], inst: bigint) => list.some(x => x === inst);
-const containsPair = (list: bigint[], inst: bigint, key: bigint) => {
-	for (let i = 0; i + 1 < list.length; i += 2) {
-		if (list[i] === inst && list[i + 1] === key) return true;
-	}
-	return false;
-};
-
-type MultiKeyed = { inst: BigNumberish; key: BigNumberish };
-const filterApprovedMulti = (list: bigint[], items: MultiKeyed | MultiKeyed[] | undefined): MultiKeyed[] => {
-	if (!items) return [];
-	const arr = Array.isArray(items) ? items : [items];
-	return arr.filter(x => containsPair(list, BigInt(x.inst.toString()), BigInt(x.key.toString())));
-};
 
 // Serialize a component data array to a Cairo Array<T> calldata fragment:
 // toCairoArray([d1, d2]) → [2, ...d1_flat, ...d2_flat]
@@ -943,126 +927,194 @@ export const submitForReview = async (trailId: bigint): Promise<boolean> => {
 };
 
 /**
- * Publishes only the components from staged changes that the trail owner approved.
- * Skips the creator_address ownership check — the contract's approval gate enforces access.
+ * Owner publishes selected items from a collaborator's proposal directly.
+ * Pass 1: writes all entity data (with proposer as creator_address for new entities).
+ * Pass 2: writes relationships + executes component deletions.
+ * Returns { publishedCount, skippedCount } so the caller can signal the result to the collaborator.
  */
-export const publishApproved = async (trailId: bigint, approval: ApprovedProposal): Promise<boolean> => {
-	const toBigInts = (list: BigNumberish[]) => list.map(x => BigInt(x.toString()));
-	const wSingle  = toBigInts(approval.w_single_keys);
-	const wDesc    = toBigInts(approval.w_description_texts);
-	const wMulti   = toBigInts(approval.w_multi_keys);
-	const dSingle  = toBigInts(approval.d_single_keys);
-	const dDesc    = toBigInts(approval.d_description_texts);
-	const dMulti   = toBigInts(approval.d_multi_keys);
+export const publishFromProposal = async (
+	proposal: CollabProposalEvent,
+	selected: Set<string>,
+): Promise<{ publishedCount: number; skippedCount: number }> => {
+	const proposerAddr = BigInt(proposal.proposer);
+	const sel = (key: string) => selected.has(key);
 
-	const staged = EditorData().get().stagedChanges.filter(c => {
-		const entity = EditorData().getEntity(c.inst);
-		return BigInt(entity?.Entity?.trail_id ?? 0) === trailId;
-	});
+	// Build fast-lookup maps: inst → item
+	const entityByInst = new Map(proposal.entities.map(e => [String(e.inst), e as unknown as Entity]));
+	const reactableByInst = new Map(proposal.reactables.map(r => [String(r.inst), r as unknown as typeof r]));
+	const areaByInst = new Map(proposal.areas.map(a => [String(a.inst), a as unknown as Area]));
+	const exitByInst = new Map(proposal.exits.map(e => [String(e.inst), e as unknown as Exit]));
+	const hubByInst = new Map(proposal.hubs.map(h => [String(h.inst), h as unknown as Hub]));
+	const trailByInst = new Map(proposal.trails.map(t => [String(t.inst), t as unknown as Trail]));
+	const containerByInst = new Map(proposal.containers.map(c => [String(c.inst), c as unknown as Container]));
+	const invItemByInst = new Map(proposal.inventory_items.map(i => [String(i.inst), i as unknown as InventoryItem]));
+	const parentByInst = new Map(proposal.parents.map(p => [String(p.inst), p as unknown as ParentToChildren]));
+	const childByInst = new Map(proposal.children.map(c => [String(c.inst), c as unknown as ChildToParent]));
 
-	if (staged.length === 0) {
-		toast.info("Nothing staged for this trail.");
-		return false;
+	// Multi-keyed items — map by "inst:key"
+	const dtByInstKey = new Map(proposal.description_texts.map(dt => [`${dt.inst}:${dt.key}`, dt as unknown as DescriptionText]));
+	const triggerByInstKey = new Map(proposal.triggers.map(t => [`${t.inst}:${t.key}`, t as unknown as Trigger]));
+	const condByInstKey = new Map(proposal.conditions.map(c => [`${c.inst}:${c.key}`, c as unknown as Condition]));
+	const effectByInstKey = new Map(proposal.effects.map(e => [`${e.inst}:${e.key}`, e as unknown as Effect]));
+	const actionByInstKey = new Map(proposal.actions.map(a => [`${a.inst}:${a.key}`, a as unknown as Action]));
+
+	// All selectable write keys across the whole proposal
+	const allWriteKeys: string[] = [];
+	for (const e of proposal.entities) allWriteKeys.push(`w:${e.inst}:Entity`);
+	for (const r of proposal.reactables) allWriteKeys.push(`w:${r.inst}:Reactable`);
+	for (const a of proposal.areas) allWriteKeys.push(`w:${a.inst}:Area`);
+	for (const e of proposal.exits) allWriteKeys.push(`w:${e.inst}:Exit`);
+	for (const h of proposal.hubs) allWriteKeys.push(`w:${h.inst}:Hub`);
+	for (const t of proposal.trails) allWriteKeys.push(`w:${t.inst}:Trail`);
+	for (const c of proposal.containers) allWriteKeys.push(`w:${c.inst}:Container`);
+	for (const i of proposal.inventory_items) allWriteKeys.push(`w:${i.inst}:InventoryItem`);
+	for (const p of proposal.parents) allWriteKeys.push(`w:${p.inst}:ParentToChildren`);
+	for (const c of proposal.children) allWriteKeys.push(`w:${c.inst}:ChildToParent`);
+	for (const dt of proposal.description_texts) allWriteKeys.push(`w:${dt.inst}:DescriptionText:${dt.key}`);
+	for (const t of proposal.triggers) allWriteKeys.push(`w:${t.inst}:Trigger:${t.key}`);
+	for (const c of proposal.conditions) allWriteKeys.push(`w:${c.inst}:Condition:${c.key}`);
+	for (const e of proposal.effects) allWriteKeys.push(`w:${e.inst}:Effect:${e.key}`);
+	for (const a of proposal.actions) allWriteKeys.push(`w:${a.inst}:Action:${a.key}`);
+	// Deletion keys
+	const delPairToKeys = (flat: BigNumberish[], comp: string) => {
+		const keys: string[] = [];
+		for (let i = 0; i + 1 < flat.length; i += 2) keys.push(`d:${flat[i]}:${comp}:${flat[i + 1]}`);
+		return keys;
+	};
+	for (const inst of proposal.deleted_reactable_insts) allWriteKeys.push(`d:${inst}:Reactable`);
+	for (const inst of proposal.deleted_area_insts) allWriteKeys.push(`d:${inst}:Area`);
+	for (const inst of proposal.deleted_exit_insts) allWriteKeys.push(`d:${inst}:Exit`);
+	for (const inst of proposal.deleted_container_insts) allWriteKeys.push(`d:${inst}:Container`);
+	for (const inst of proposal.deleted_inventory_item_insts) allWriteKeys.push(`d:${inst}:InventoryItem`);
+	for (const inst of proposal.deleted_hub_insts) allWriteKeys.push(`d:${inst}:Hub`);
+	for (const inst of proposal.deleted_trail_insts) allWriteKeys.push(`d:${inst}:Trail`);
+	for (const inst of proposal.deleted_parent_insts) allWriteKeys.push(`d:${inst}:ParentToChildren`);
+	for (const inst of proposal.deleted_child_insts) allWriteKeys.push(`d:${inst}:ChildToParent`);
+	allWriteKeys.push(...delPairToKeys(proposal.deleted_description_text_keys as BigNumberish[], "DescriptionText"));
+	allWriteKeys.push(...delPairToKeys(proposal.deleted_trigger_keys as BigNumberish[], "Trigger"));
+	allWriteKeys.push(...delPairToKeys(proposal.deleted_condition_keys as BigNumberish[], "Condition"));
+	allWriteKeys.push(...delPairToKeys(proposal.deleted_effect_keys as BigNumberish[], "Effect"));
+	allWriteKeys.push(...delPairToKeys(proposal.deleted_action_keys as BigNumberish[], "Action"));
+
+	const totalItems = allWriteKeys.length;
+	const selectedItems = allWriteKeys.filter(k => selected.has(k));
+
+	if (selectedItems.length === 0) {
+		return { publishedCount: 0, skippedCount: totalItems };
 	}
 
-	// Track original references alongside the filtered copies so pass-2 cleanup can use
-	// reference equality to remove the right entries from stagedChanges/changeSet.
-	type ApprovedEntry = { original: ChangeSet; filtered: ChangeSet };
-	const approvedChanges: ApprovedEntry[] = [];
-
-	for (const change of staged) {
-		const col = change.object; // EditorCollection — enum fields are already string-typed
-		const inst = BigInt(change.inst.toString());
-
-		const buildFiltered = (singleList: bigint[], descList: bigint[], multiList: bigint[]): EditorCollection => {
-			const out: EditorCollection = {};
-			if (col.Entity           && containsInst(singleList, inst)) out.Entity = col.Entity;
-			if (col.Reactable        && containsInst(singleList, inst)) out.Reactable = col.Reactable;
-			if (col.Area             && containsInst(singleList, inst)) out.Area = col.Area;
-			if (col.Exit             && containsInst(singleList, inst)) out.Exit = col.Exit;
-			if (col.Hub              && containsInst(singleList, inst)) out.Hub = col.Hub;
-			if (col.InventoryItem    && containsInst(singleList, inst)) out.InventoryItem = col.InventoryItem;
-			if (col.Container        && containsInst(singleList, inst)) out.Container = col.Container;
-			if (col.Trail            && containsInst(singleList, inst)) out.Trail = col.Trail;
-			if (col.ParentToChildren && containsInst(singleList, inst)) out.ParentToChildren = col.ParentToChildren;
-			if (col.ChildToParent    && containsInst(singleList, inst)) out.ChildToParent = col.ChildToParent;
-			if (col.DescriptionText) {
-				const ok = filterApprovedMulti(descList, (Array.isArray(col.DescriptionText) ? col.DescriptionText : [col.DescriptionText]) as MultiKeyed[]);
-				if (ok.length > 0) out.DescriptionText = ok as DescriptionText[];
-			}
-			const applyMulti = <T extends MultiKeyed>(src: T | T[] | undefined, key: "Trigger" | "Condition" | "Effect" | "Action") => {
-				const ok = filterApprovedMulti(multiList, src as MultiKeyed | MultiKeyed[] | undefined) as T[];
-				if (ok.length > 0) (out as Record<string, unknown>)[key] = ok.length === 1 ? ok[0] : ok;
-			};
-			applyMulti(col.Trigger as Trigger | Trigger[] | undefined, "Trigger");
-			applyMulti(col.Condition as Condition | Condition[] | undefined, "Condition");
-			applyMulti(col.Effect as Effect | Effect[] | undefined, "Effect");
-			applyMulti(col.Action as Action | Action[] | undefined, "Action");
-			return out;
-		};
-
-		const filtered = change.type === "delete"
-			? buildFiltered(dSingle, dDesc, dMulti)
-			: buildFiltered(wSingle, wDesc, wMulti);
-
-		if (Object.keys(filtered).length > 0) {
-			approvedChanges.push({ original: change, filtered: { ...change, object: filtered } });
-		}
-	}
-
-	if (approvedChanges.length === 0) {
-		toast.info("No approved changes to publish.");
-		return false;
-	}
-
-	const publishedInsts = [...new Set(approvedChanges.map(e => e.original.inst))];
+	// Helper to check if an entity is new (not yet on-chain in syncPool)
+	const isNewEntity = (inst: BigNumberish) => EditorData().getEntity(String(inst), true) === undefined;
 
 	try {
 		await Notifications().startPublishing();
 
-		// Pass 1: entity data (no parent-child relationships).
-		// All entities must exist on-chain before any ChildToParent is written,
-		// regardless of the order they appear in stagedChanges.
-		for (const { filtered } of approvedChanges) {
-			if (filtered.type === "update") {
-				await publishEntityData(filtered.object as EntityCollection);
+		// Pass 1: entity data (no relationship writes)
+		for (const key of selectedItems) {
+			const [prefix, inst, comp, itemKey] = key.split(":");
+			if (prefix !== "w") continue;
+			try {
+				if (comp === "Entity") {
+					const e = entityByInst.get(inst);
+					if (e) await publishEntity(e as Entity, isNewEntity(inst) ? proposerAddr : undefined);
+				} else if (comp === "Reactable") {
+					const r = reactableByInst.get(inst);
+					if (r) await publishReactable(r as Reactable);
+				} else if (comp === "Area") {
+					const a = areaByInst.get(inst);
+					if (a) await publishArea(a as Area);
+				} else if (comp === "Exit") {
+					const e = exitByInst.get(inst);
+					if (e) await publishExit(e as Exit);
+				} else if (comp === "Hub") {
+					const h = hubByInst.get(inst);
+					if (h) await publishHub(h as Hub);
+				} else if (comp === "Trail") {
+					const t = trailByInst.get(inst);
+					if (t) await publishTrail(t as Trail);
+				} else if (comp === "Container") {
+					const c = containerByInst.get(inst);
+					if (c) await publishContainer(c as Container);
+				} else if (comp === "InventoryItem") {
+					const i = invItemByInst.get(inst);
+					if (i) await publishInventoryItem(i as InventoryItem);
+				} else if (comp === "DescriptionText") {
+					const dt = dtByInstKey.get(`${inst}:${itemKey}`);
+					if (dt) await publishDescriptionText(dt as DescriptionText);
+				} else if (comp === "Trigger") {
+					const t = triggerByInstKey.get(`${inst}:${itemKey}`);
+					if (t) await publishTrigger(t as Trigger);
+				} else if (comp === "Condition") {
+					const c = condByInstKey.get(`${inst}:${itemKey}`);
+					if (c) await publishCondition(c as Condition);
+				} else if (comp === "Effect") {
+					const e = effectByInstKey.get(`${inst}:${itemKey}`);
+					if (e) await publishEffect(e as Effect);
+				} else if (comp === "Action") {
+					const a = actionByInstKey.get(`${inst}:${itemKey}`);
+					if (a) await publishAction(a as Action);
+				}
+				// ParentToChildren / ChildToParent are deferred to pass 2
+			} catch (err) {
+				console.error(`Error publishing ${key}:`, err);
+				throw err;
 			}
 		}
 
-		// Pass 2: parent-child relationships + deletes + cleanup.
-		for (const { original, filtered } of approvedChanges) {
-			if (filtered.type === "update") {
-				await publishEntityRelationships(filtered.object as EntityCollection);
-			} else {
-				await deleteCollection(filtered.object as EntityCollection);
+		// Pass 2: relationships + deletions
+		for (const key of selectedItems) {
+			const [prefix, inst, comp, itemKey] = key.split(":");
+			try {
+				if (prefix === "w") {
+					if (comp === "ParentToChildren") {
+						const p = parentByInst.get(inst);
+						if (p) await publishParentToChildren(p as ParentToChildren);
+					} else if (comp === "ChildToParent") {
+						const c = childByInst.get(inst);
+						if (c) await publishChildToParent(c as ChildToParent);
+					}
+				} else if (prefix === "d") {
+					const instBig = num.toBigInt(inst);
+					if (comp === "Reactable") await dispatchDesignerCall("delete_reactable", [instBig]);
+					else if (comp === "Area") await dispatchDesignerCall("delete_area", [instBig]);
+					else if (comp === "Exit") await dispatchDesignerCall("delete_exit", [instBig]);
+					else if (comp === "Container") await dispatchDesignerCall("delete_container", [instBig]);
+					else if (comp === "InventoryItem") await dispatchDesignerCall("delete_inventory_item", [instBig]);
+					else if (comp === "Hub") await dispatchDesignerCall("delete_hub", [instBig]);
+					else if (comp === "Trail") await dispatchDesignerCall("delete_trail", [instBig]);
+					else if (comp === "ParentToChildren") await dispatchDesignerCall("delete_parent", [instBig]);
+					else if (comp === "ChildToParent") await dispatchDesignerCall("delete_child", [instBig]);
+					else if (comp === "DescriptionText") await dispatchDesignerCall("delete_description_text", [[instBig, num.toBigInt(itemKey)]]);
+					else if (comp === "Trigger") await dispatchDesignerCall("delete_trigger", [[instBig, num.toBigInt(itemKey)]]);
+					else if (comp === "Condition") await dispatchDesignerCall("delete_condition", [[instBig, num.toBigInt(itemKey)]]);
+					else if (comp === "Effect") await dispatchDesignerCall("delete_effect", [[instBig, num.toBigInt(itemKey)]]);
+					else if (comp === "Action") await dispatchDesignerCall("delete_action", [[instBig, num.toBigInt(itemKey)]]);
+				}
+			} catch (err) {
+				console.error(`Error publishing ${key}:`, err);
+				throw err;
 			}
-			EditorData().set({
-				changeSet: EditorData().changeSet.filter(x => x !== original),
-				stagedChanges: EditorData().get().stagedChanges.filter(x => x !== original),
-			});
-			persistDraft();
 		}
 
 		Notifications().finalizePublishing();
 
-		// Remove the published approval so the "Approved by trail owner" banner disappears.
-		const norm = (addr: string) => addr.replace(/^0x0+/, "0x").toLowerCase();
-		const proposerNorm = norm(approval.proposer);
-		EditorData().set({
-			currentApprovals: EditorData().get().currentApprovals.filter(
-				(a) => !(BigInt(a.trail_id) === trailId && norm(a.proposer) === proposerNorm)
-			),
-		});
-
-		await tick();
-		await syncEntitiesByInsts(publishedInsts);
-		return true;
+		const publishedCount = selectedItems.length;
+		const skippedCount = totalItems - publishedCount;
+		return { publishedCount, skippedCount };
 	} catch (error) {
 		const errorMsg = error instanceof Error ? error.message : String(error);
-		Notifications().showError(`Error publishing approved changes: ${errorMsg}`);
-		return false;
+		Notifications().showError(`Error publishing proposal: ${errorMsg}`);
+		throw error;
 	}
 };
+
+/** Re-exported for use in RemoteChangesPanel without a separate SystemCalls import. */
+export const signalReviewResult = (
+	trailId: bigint,
+	proposer: string,
+	publishedCount: number,
+	skippedCount: number,
+) => SystemCalls.signalReviewResult(trailId, proposer, publishedCount, skippedCount);
 
 /**
  * Helper function to send designer call

--- a/packages/client/src/lib/dojo.ts
+++ b/packages/client/src/lib/dojo.ts
@@ -77,7 +77,7 @@ export const InitDojo = async () => {
 					"lore-PlayerStory",
 					"lore-Hub",
 					"lore-Trail",
-					"lore-ApprovedProposal",
+					"lore-CollabReviewResult",
 				]);
 			return query;
 		};

--- a/packages/client/src/lib/dojo_bindings/typescript/contracts.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/contracts.gen.ts
@@ -476,27 +476,6 @@ export function setupWorld(provider: DojoProvider) {
 		}
 	};
 
-	const build_designer_approveProposal_calldata = (proposal: models.ApprovedProposal): DojoCall => {
-		return {
-			contractName: "designer",
-			entrypoint: "approve_proposal",
-			calldata: [proposal],
-		};
-	};
-
-	const designer_approveProposal = async (snAccount: Account | AccountInterface, proposal: models.ApprovedProposal) => {
-		try {
-			return await provider.execute(
-				snAccount,
-				build_designer_approveProposal_calldata(proposal),
-				"lore",
-			);
-		} catch (error) {
-			console.error(error);
-			throw error;
-		}
-	};
-
 	const build_designer_createAction_calldata = (t: Array<Action>): DojoCall => {
 		return {
 			contractName: "designer",
@@ -1321,27 +1300,6 @@ export function setupWorld(provider: DojoProvider) {
 		}
 	};
 
-	const build_designer_rejectProposal_calldata = (trailId: BigNumberish, proposer: string): DojoCall => {
-		return {
-			contractName: "designer",
-			entrypoint: "reject_proposal",
-			calldata: [trailId, proposer],
-		};
-	};
-
-	const designer_rejectProposal = async (snAccount: Account | AccountInterface, trailId: BigNumberish, proposer: string) => {
-		try {
-			return await provider.execute(
-				snAccount,
-				build_designer_rejectProposal_calldata(trailId, proposer),
-				"lore",
-			);
-		} catch (error) {
-			console.error(error);
-			throw error;
-		}
-	};
-
 	const build_designer_renounceRole_calldata = (role: BigNumberish, account: string): DojoCall => {
 		return {
 			contractName: "designer",
@@ -1418,6 +1376,27 @@ export function setupWorld(provider: DojoProvider) {
 			return await provider.execute(
 				snAccount,
 				build_designer_setEditor_calldata(account, isEditor),
+				"lore",
+			);
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
+	const build_designer_signalReviewResult_calldata = (trailId: BigNumberish, proposer: string, publishedCount: BigNumberish, skippedCount: BigNumberish): DojoCall => {
+		return {
+			contractName: "designer",
+			entrypoint: "signal_review_result",
+			calldata: [trailId, proposer, publishedCount, skippedCount],
+		};
+	};
+
+	const designer_signalReviewResult = async (snAccount: Account | AccountInterface, trailId: BigNumberish, proposer: string, publishedCount: BigNumberish, skippedCount: BigNumberish) => {
+		try {
+			return await provider.execute(
+				snAccount,
+				build_designer_signalReviewResult_calldata(trailId, proposer, publishedCount, skippedCount),
 				"lore",
 			);
 		} catch (error) {
@@ -2707,8 +2686,6 @@ export function setupWorld(provider: DojoProvider) {
 			buildTransferFromCalldata: build_actions_token_transferFrom_calldata,
 		},
 		designer: {
-			approveProposal: designer_approveProposal,
-			buildApproveProposalCalldata: build_designer_approveProposal_calldata,
 			createAction: designer_createAction,
 			buildCreateActionCalldata: build_designer_createAction_calldata,
 			createArea: designer_createArea,
@@ -2789,8 +2766,6 @@ export function setupWorld(provider: DojoProvider) {
 			buildIsEditorCalldata: build_designer_isEditor_calldata,
 			registerPropertyRegistry: designer_registerPropertyRegistry,
 			buildRegisterPropertyRegistryCalldata: build_designer_registerPropertyRegistry_calldata,
-			rejectProposal: designer_rejectProposal,
-			buildRejectProposalCalldata: build_designer_rejectProposal_calldata,
 			renounceRole: designer_renounceRole,
 			buildRenounceRoleCalldata: build_designer_renounceRole_calldata,
 			revokeRole: designer_revokeRole,
@@ -2799,6 +2774,8 @@ export function setupWorld(provider: DojoProvider) {
 			buildSetAdminCalldata: build_designer_setAdmin_calldata,
 			setEditor: designer_setEditor,
 			buildSetEditorCalldata: build_designer_setEditor_calldata,
+			signalReviewResult: designer_signalReviewResult,
+			buildSignalReviewResultCalldata: build_designer_signalReviewResult_calldata,
 			submitForReview: designer_submitForReview,
 			buildSubmitForReviewCalldata: build_designer_submitForReview_calldata,
 			supportsInterface: designer_supportsInterface,

--- a/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
+++ b/packages/client/src/lib/dojo_bindings/typescript/models.gen.ts
@@ -53,16 +53,12 @@ export interface Area {
 	preserve_children: boolean;
 }
 
-// Type definition for `lore::models::collab_proposal::ApprovedProposal` struct
-export interface ApprovedProposal {
+// Type definition for `lore::models::collab_proposal::CollabReviewResult` struct
+export interface CollabReviewResult {
 	trail_id: BigNumberish;
 	proposer: string;
-	w_single_keys: Array<BigNumberish>;
-	w_description_texts: Array<BigNumberish>;
-	w_multi_keys: Array<BigNumberish>;
-	d_single_keys: Array<BigNumberish>;
-	d_description_texts: Array<BigNumberish>;
-	d_multi_keys: Array<BigNumberish>;
+	published_count: BigNumberish;
+	skipped_count: BigNumberish;
 }
 
 // Type definition for `lore::models::condition::Condition` struct
@@ -758,7 +754,7 @@ export interface SchemaType extends ISchemaType {
 		ActionsConfig: ActionsConfig,
 		ActionsReward: ActionsReward,
 		Area: Area,
-		ApprovedProposal: ApprovedProposal,
+		CollabReviewResult: CollabReviewResult,
 		Condition: Condition,
 		Container: Container,
 		DescriptionText: DescriptionText,
@@ -853,15 +849,11 @@ export const schema: SchemaType = {
 			progress_percentage: 0,
 			preserve_children: false,
 		},
-		ApprovedProposal: {
+		CollabReviewResult: {
 			trail_id: 0,
 			proposer: "",
-			w_single_keys: [0],
-			w_description_texts: [0],
-			w_multi_keys: [0],
-			d_single_keys: [0],
-			d_description_texts: [0],
-			d_multi_keys: [0],
+			published_count: 0,
+			skipped_count: 0,
 		},
 		Condition: {
 			inst: 0,
@@ -1446,7 +1438,7 @@ export enum ModelsMapping {
 	ActionsConfig = 'lore-ActionsConfig',
 	ActionsReward = 'lore-ActionsReward',
 	Area = 'lore-Area',
-	ApprovedProposal = 'lore-ApprovedProposal',
+	CollabReviewResult = 'lore-CollabReviewResult',
 	Condition = 'lore-Condition',
 	Container = 'lore-Container',
 	DescriptionText = 'lore-DescriptionText',

--- a/packages/client/src/lib/stores/wallet.store.ts
+++ b/packages/client/src/lib/stores/wallet.store.ts
@@ -244,12 +244,8 @@ const setupController = async () => {
 							description: `The terminal endpoint for ${APP_EDITOR_DATA.title} submitting changes for trail owner review`,
 						},
 						{
-							entrypoint: "approve_proposal",
-							description: `The terminal endpoint for ${APP_EDITOR_DATA.title} approving a collaborator proposal`,
-						},
-						{
-							entrypoint: "reject_proposal",
-							description: `The terminal endpoint for ${APP_EDITOR_DATA.title} rejecting a collaborator proposal`,
+							entrypoint: "signal_review_result",
+							description: `The terminal endpoint for ${APP_EDITOR_DATA.title} signalling the result of a proposal review`,
 						},
 					],
 				},

--- a/packages/client/src/lib/systemCalls.ts
+++ b/packages/client/src/lib/systemCalls.ts
@@ -5,7 +5,6 @@ import { sendCommand } from "./terminalCommands/commandHandler";
 import { addTerminalContent } from "@lib/stores/terminal.store";
 import { DojoCall } from "@dojoengine/core";
 import WalletStore from "./stores/wallet.store";
-import type { ApprovedProposal } from "@lib/dojo_bindings/typescript/models.gen";
 
 /**
  * Sends a command to the entity contract.
@@ -110,8 +109,7 @@ export type DesignerEntrypoints =
 	| "delete_parent"
 	| "delete_child"
 	| "submit_for_review"
-	| "approve_proposal"
-	| "reject_proposal";
+	| "signal_review_result";
 
 type DesignerCallProps = {
 	entrypoint: DesignerEntrypoints;
@@ -177,22 +175,13 @@ function validateReceiptStatus(receipt: any, calls?: (Call | DojoCall)[]): boole
 }
 
 
-async function approveProposal(proposal: ApprovedProposal): Promise<void> {
+async function signalReviewResult(trailId: bigint, proposer: string, publishedCount: number, skippedCount: number): Promise<void> {
 	if (!WalletStore().isConnected) return;
 	const caller = WalletStore().account as Account;
-	const calldata = CallData.compile([
-		proposal.trail_id,
-		proposal.proposer,
-		proposal.w_single_keys,
-		proposal.w_description_texts,
-		proposal.w_multi_keys,
-		proposal.d_single_keys,
-		proposal.d_description_texts,
-		proposal.d_multi_keys,
-	]);
+	const calldata = CallData.compile([trailId, proposer, publishedCount, skippedCount]);
 	const calls: Call[] = [{
 		contractAddress: LORE_CONFIG.contractAddresses.designer,
-		entrypoint: "approve_proposal",
+		entrypoint: "signal_review_result",
 		calldata,
 	}];
 	try {
@@ -203,29 +192,7 @@ async function approveProposal(proposal: ApprovedProposal): Promise<void> {
 			});
 		}
 	} catch (error) {
-		console.error("❌ DESIGNER ERROR: approveProposal():", calls, error as Error);
-		throw new Error((error as Error).message);
-	}
-}
-
-async function rejectProposal(trailId: bigint, proposer: string): Promise<void> {
-	if (!WalletStore().isConnected) return;
-	const caller = WalletStore().account as Account;
-	const calldata = CallData.compile([trailId, proposer]);
-	const calls: Call[] = [{
-		contractAddress: LORE_CONFIG.contractAddresses.designer,
-		entrypoint: "reject_proposal",
-		calldata,
-	}];
-	try {
-		const response = await caller.execute(calls, { tip: 0 });
-		if (response) {
-			await caller.waitForTransaction(response.transaction_hash, { retryInterval: 200 }).then((receipt) => {
-				validateReceiptStatus(receipt, calls);
-			});
-		}
-	} catch (error) {
-		console.error("❌ DESIGNER ERROR: rejectProposal():", calls, error as Error);
+		console.error("❌ DESIGNER ERROR: signalReviewResult():", calls, error as Error);
 		throw new Error((error as Error).message);
 	}
 }
@@ -264,6 +231,5 @@ export const SystemCalls = {
 	execDesignerCall,
 	execCommand,
 	grantAccessToTrail,
-	approveProposal,
-	rejectProposal,
+	signalReviewResult,
 };

--- a/packages/contracts/manifest_dev.json
+++ b/packages/contracts/manifest_dev.json
@@ -63,8 +63,8 @@
       ]
     },
     {
-      "address": "0x248c43be7921fe958a398e4c6219c13f84aba208b7f728e1dd704cd16633a5a",
-      "class_hash": "0x4399e23544d320a4e2e5efc5430823c7393738e2ddd3de04552c8a028a63136",
+      "address": "0x69b4151c8a117a3fdb20276665a175d10a8fbe48186f0d388dfc1572946e279",
+      "class_hash": "0xf821ae3d10277b5b5ec763c65432174caf54736d2efa2cf268d979bbf58ba9",
       "init_calldata": [
         "arr:0x6677fe62ee39c7b07401f754138502bab7fac99d2d3c5d37df7d1c6fab10819,0x034ae3F2ba263AB26cce840E78C4B0b314F9412b40E78491C14846d58AE712c7,0x00957880Ae68d68b4B8Aa491cE1b65439a6539d546850941fc9a54e255AD64Ae,0x0550212D3F13a373DfE9e3Ef6aA41fBA4124BDe63FD7955393f879De19f3F47F"
       ],
@@ -110,8 +110,7 @@
         "delete_child",
         "register_property_registry",
         "submit_for_review",
-        "approve_proposal",
-        "reject_proposal",
+        "signal_review_result",
         "upgrade",
         "grant_role",
         "revoke_role",
@@ -349,53 +348,6 @@
     {
       "members": [
         {
-          "name": "trail_id",
-          "type": "core::integer::u128",
-          "key": true
-        },
-        {
-          "name": "proposer",
-          "type": "core::starknet::contract_address::ContractAddress",
-          "key": true
-        },
-        {
-          "name": "w_single_keys",
-          "type": "core::array::Array::<core::felt252>",
-          "key": false
-        },
-        {
-          "name": "w_description_texts",
-          "type": "core::array::Array::<core::felt252>",
-          "key": false
-        },
-        {
-          "name": "w_multi_keys",
-          "type": "core::array::Array::<core::felt252>",
-          "key": false
-        },
-        {
-          "name": "d_single_keys",
-          "type": "core::array::Array::<core::felt252>",
-          "key": false
-        },
-        {
-          "name": "d_description_texts",
-          "type": "core::array::Array::<core::felt252>",
-          "key": false
-        },
-        {
-          "name": "d_multi_keys",
-          "type": "core::array::Array::<core::felt252>",
-          "key": false
-        }
-      ],
-      "class_hash": "0x57d62e47de9b1c87b2e8c9182d6840c2f32608f3ede4fd6639923683c1adf33",
-      "tag": "lore-ApprovedProposal",
-      "selector": "0x28430bf634ef643bbabbf357d81d474eeb35f74bb6ef7fbcd41fc0523d5331d"
-    },
-    {
-      "members": [
-        {
           "name": "inst",
           "type": "core::felt252",
           "key": true
@@ -446,6 +398,33 @@
       "class_hash": "0x35170eb5278f2e24c6f2a9f7e2adba47f15cf0d8544c6519632567eb0c497c3",
       "tag": "lore-ChildToParent",
       "selector": "0x6c2a358df76ae2ca942ea3cc2f59ade04e5f5ba87ee162b41a10ad5a5755287"
+    },
+    {
+      "members": [
+        {
+          "name": "trail_id",
+          "type": "core::integer::u128",
+          "key": true
+        },
+        {
+          "name": "proposer",
+          "type": "core::starknet::contract_address::ContractAddress",
+          "key": true
+        },
+        {
+          "name": "published_count",
+          "type": "core::integer::u32",
+          "key": false
+        },
+        {
+          "name": "skipped_count",
+          "type": "core::integer::u32",
+          "key": false
+        }
+      ],
+      "class_hash": "0x7eb4ae798f23433b2669fe0d1b14648fb1f17b6e4fe1d86a131ad6b32b294f4",
+      "tag": "lore-CollabReviewResult",
+      "selector": "0x68ac832bd72b6971eea85e41d70a4179555020f3d8395393d6858b23914114"
     },
     {
       "members": [
@@ -4526,74 +4505,6 @@
     },
     {
       "type": "struct",
-      "name": "lore::models::collab_proposal::ApprovedProposal",
-      "members": [
-        {
-          "name": "trail_id",
-          "type": "core::integer::u128"
-        },
-        {
-          "name": "proposer",
-          "type": "core::starknet::contract_address::ContractAddress"
-        },
-        {
-          "name": "w_single_keys",
-          "type": "core::array::Array::<core::felt252>"
-        },
-        {
-          "name": "w_description_texts",
-          "type": "core::array::Array::<core::felt252>"
-        },
-        {
-          "name": "w_multi_keys",
-          "type": "core::array::Array::<core::felt252>"
-        },
-        {
-          "name": "d_single_keys",
-          "type": "core::array::Array::<core::felt252>"
-        },
-        {
-          "name": "d_description_texts",
-          "type": "core::array::Array::<core::felt252>"
-        },
-        {
-          "name": "d_multi_keys",
-          "type": "core::array::Array::<core::felt252>"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "lore::models::collab_proposal::ApprovedProposalValue",
-      "members": [
-        {
-          "name": "w_single_keys",
-          "type": "core::array::Array::<core::felt252>"
-        },
-        {
-          "name": "w_description_texts",
-          "type": "core::array::Array::<core::felt252>"
-        },
-        {
-          "name": "w_multi_keys",
-          "type": "core::array::Array::<core::felt252>"
-        },
-        {
-          "name": "d_single_keys",
-          "type": "core::array::Array::<core::felt252>"
-        },
-        {
-          "name": "d_description_texts",
-          "type": "core::array::Array::<core::felt252>"
-        },
-        {
-          "name": "d_multi_keys",
-          "type": "core::array::Array::<core::felt252>"
-        }
-      ]
-    },
-    {
-      "type": "struct",
       "name": "lore::models::collab_proposal::CollabProposalEvent",
       "members": [
         {
@@ -4853,6 +4764,42 @@
       ]
     },
     {
+      "type": "struct",
+      "name": "lore::models::collab_proposal::CollabReviewResult",
+      "members": [
+        {
+          "name": "trail_id",
+          "type": "core::integer::u128"
+        },
+        {
+          "name": "proposer",
+          "type": "core::starknet::contract_address::ContractAddress"
+        },
+        {
+          "name": "published_count",
+          "type": "core::integer::u32"
+        },
+        {
+          "name": "skipped_count",
+          "type": "core::integer::u32"
+        }
+      ]
+    },
+    {
+      "type": "struct",
+      "name": "lore::models::collab_proposal::CollabReviewResultValue",
+      "members": [
+        {
+          "name": "published_count",
+          "type": "core::integer::u32"
+        },
+        {
+          "name": "skipped_count",
+          "type": "core::integer::u32"
+        }
+      ]
+    },
+    {
       "type": "event",
       "name": "lore::models::collab_proposal::e_CollabProposalEvent::Event",
       "kind": "enum",
@@ -4860,7 +4807,7 @@
     },
     {
       "type": "event",
-      "name": "lore::models::collab_proposal::m_ApprovedProposal::Event",
+      "name": "lore::models::collab_proposal::m_CollabReviewResult::Event",
       "kind": "enum",
       "variants": []
     },
@@ -7364,19 +7311,7 @@
         },
         {
           "type": "function",
-          "name": "approve_proposal",
-          "inputs": [
-            {
-              "name": "proposal",
-              "type": "lore::models::collab_proposal::ApprovedProposal"
-            }
-          ],
-          "outputs": [],
-          "state_mutability": "external"
-        },
-        {
-          "type": "function",
-          "name": "reject_proposal",
+          "name": "signal_review_result",
           "inputs": [
             {
               "name": "trail_id",
@@ -7385,6 +7320,14 @@
             {
               "name": "proposer",
               "type": "core::starknet::contract_address::ContractAddress"
+            },
+            {
+              "name": "published_count",
+              "type": "core::integer::u32"
+            },
+            {
+              "name": "skipped_count",
+              "type": "core::integer::u32"
             }
           ],
           "outputs": [],

--- a/packages/contracts/src/models/collab_proposal.cairo
+++ b/packages/contracts/src/models/collab_proposal.cairo
@@ -14,67 +14,25 @@ use lore::models::{
     hub::{Hub, Trail},
 };
 
-// Three approval buckets per direction (write / delete):
-//
-//  w_single_keys / d_single_keys
-//      Flat list of inst values (felt252) for all single-key component types:
-//      Entity, Reactable, Area, Exit, Hub, InventoryItem, Container, Trail,
-//      ParentToChildren, ChildToParent.
-//
-//  w_description_texts / d_description_texts
-//      Flat pairs [inst, key_as_felt252, ...] for DescriptionText (inst, u32 key).
-//      Kept separate so the owner can approve structural components but reject content.
-//
-//  w_multi_keys / d_multi_keys
-//      Flat pairs [inst, key, ...] for the remaining multi-key types:
-//      Trigger, Condition, Effect, Action.
+// Written by the trail owner after publishing a collaborator's proposal.
+// Keys: (trail_id, proposer) — one record per collaborator per trail.
+// Delivered to the collaborator via the standard entity subscription so they can show
+// the appropriate notification (all published / partial / rejected).
 #[derive(Clone, Drop, Serde, Introspect)]
 #[dojo::model]
-pub struct ApprovedProposal {
-    #[key]
-    pub trail_id: u128,
-    #[key]
-    pub proposer: ContractAddress,
-    pub w_single_keys:       Array<felt252>,
-    pub w_description_texts: Array<felt252>,
-    pub w_multi_keys:        Array<felt252>,
-    pub d_single_keys:       Array<felt252>,
-    pub d_description_texts: Array<felt252>,
-    pub d_multi_keys:        Array<felt252>,
-}
-
-// Returns true if `inst` is present in `list`.
-pub fn contains_inst(mut list: Span<felt252>, inst: felt252) -> bool {
-    loop {
-        match list.pop_front() {
-            Option::None => { break false; },
-            Option::Some(i) => { if *i == inst { break true; } },
-        }
-    }
-}
-
-// Returns true if the (inst, key) pair appears as consecutive elements in `list`.
-pub fn contains_pair(mut list: Span<felt252>, inst: felt252, key: felt252) -> bool {
-    loop {
-        match list.pop_front() {
-            Option::None => { break false; },
-            Option::Some(i) => {
-                match list.pop_front() {
-                    Option::None => { break false; },
-                    Option::Some(k) => { if *i == inst && *k == key { break true; } },
-                }
-            },
-        }
-    }
+pub struct CollabReviewResult {
+    #[key] pub trail_id: u128,
+    #[key] pub proposer: ContractAddress,
+    pub published_count: u32,  // items the owner chose to publish
+    pub skipped_count:   u32,  // items from the proposal that were not published (0 = all published)
 }
 
 #[derive(Drop, Serde)]
 #[dojo::event(historical: false)]
 pub struct CollabProposalEvent {
-    #[key]
-    pub trail_id:             u128,
-    #[key]
-    pub proposer:             ContractAddress,
+    #[key] pub trail_id:             u128,
+    #[key] pub proposer:             ContractAddress,
+    // write proposals
     pub entities:             Array<Entity>,
     pub reactables:           Array<Reactable>,
     pub areas:                Array<Area>,
@@ -90,8 +48,9 @@ pub struct CollabProposalEvent {
     pub actions:              Array<Action>,
     pub parents:              Array<ParentToChildren>,
     pub children:             Array<ChildToParent>,
+    // entity-level deletions (owner-only; collaborators must leave this empty)
     pub deleted_entity_insts:          Array<felt252>,
-    // component-level deletions — single-key (just inst), multi-key (flat [inst, key, ...] pairs)
+    // component-level deletions — single-key (flat inst list)
     pub deleted_reactable_insts:       Array<felt252>,
     pub deleted_area_insts:            Array<felt252>,
     pub deleted_exit_insts:            Array<felt252>,
@@ -101,6 +60,7 @@ pub struct CollabProposalEvent {
     pub deleted_trail_insts:           Array<felt252>,
     pub deleted_parent_insts:          Array<felt252>,
     pub deleted_child_insts:           Array<felt252>,
+    // component-level deletions — multi-key (flat [inst, key, ...] pairs)
     pub deleted_description_text_keys: Array<felt252>,
     pub deleted_trigger_keys:          Array<felt252>,
     pub deleted_condition_keys:        Array<felt252>,

--- a/packages/contracts/src/systems/designer.cairo
+++ b/packages/contracts/src/systems/designer.cairo
@@ -14,7 +14,7 @@ use lore::{
         condition::{Condition},
         trigger::{Trigger},
         hub::{Hub, Trail},
-        collab_proposal::{ApprovedProposal},
+        collab_proposal::{CollabReviewResult},
     },
 };
 
@@ -98,8 +98,7 @@ pub trait IDesigner<TContractState> {
         deleted_effect_keys:           Array<felt252>,
         deleted_action_keys:           Array<felt252>,
     );
-    fn approve_proposal(ref self: TContractState, proposal: ApprovedProposal);
-    fn reject_proposal(ref self: TContractState, trail_id: u128, proposer: ContractAddress);
+    fn signal_review_result(ref self: TContractState, trail_id: u128, proposer: ContractAddress, published_count: u32, skipped_count: u32);
 
     // IAccessControl
     fn has_role(self: @TContractState, role: felt252, account: ContractAddress) -> bool;
@@ -189,8 +188,7 @@ pub trait IDesignerPublic<TContractState> {
         deleted_effect_keys:           Array<felt252>,
         deleted_action_keys:           Array<felt252>,
     );
-    fn approve_proposal(ref self: TContractState, proposal: ApprovedProposal);
-    fn reject_proposal(ref self: TContractState, trail_id: u128, proposer: ContractAddress);
+    fn signal_review_result(ref self: TContractState, trail_id: u128, proposer: ContractAddress, published_count: u32, skipped_count: u32);
 }
 
 #[dojo::contract]
@@ -249,7 +247,7 @@ pub mod designer {
             condition::{Condition},
             trigger::{Trigger, TriggerImpl},
             hub::{Hub, HubTrait, Trail, TrailTrait},
-            collab_proposal::{ApprovedProposal, CollabProposalEvent, contains_inst, contains_pair},
+            collab_proposal::{CollabReviewResult, CollabProposalEvent},
         },
         types::{
             component_type::ComponentType,
@@ -389,6 +387,11 @@ pub mod designer {
                 self.is_admin(caller) || is_trail_owner || has_trail_role,
                 Errors::NOT_COLLABORATOR,
             );
+            // Collaborators cannot propose entity deletions — those are owner-only actions.
+            assert(
+                is_trail_owner || self.is_admin(caller) || deleted_entity_insts.len() == 0,
+                Errors::NOT_TRAIL_OWNER,
+            );
             world.emit_event(@CollabProposalEvent {
                 trail_id,
                 proposer: caller,
@@ -425,21 +428,15 @@ pub mod designer {
             });
         }
 
-        fn approve_proposal(ref self: ContractState, proposal: ApprovedProposal) {
-            let caller: ContractAddress = starknet::get_caller_address();
-            let mut world: WorldStorage = self.world_default();
-            let is_trail_owner: bool = world.is_owner_of_trail(proposal.trail_id, caller);
-            assert(self.is_admin(caller) || is_trail_owner, Errors::NOT_TRAIL_OWNER);
-            world.write_model(@proposal);
-        }
-
-        fn reject_proposal(ref self: ContractState, trail_id: u128, proposer: ContractAddress) {
+        // Called by the trail owner after publishing (some or all of) a collaborator's proposal.
+        // Writes a CollabReviewResult model so the collaborator sees the outcome via entity subscription.
+        // published_count: number of items published; skipped_count: number not included (0 = all published).
+        fn signal_review_result(ref self: ContractState, trail_id: u128, proposer: ContractAddress, published_count: u32, skipped_count: u32) {
             let caller: ContractAddress = starknet::get_caller_address();
             let mut world: WorldStorage = self.world_default();
             let is_trail_owner: bool = world.is_owner_of_trail(trail_id, caller);
             assert(self.is_admin(caller) || is_trail_owner, Errors::NOT_TRAIL_OWNER);
-            let model: ApprovedProposal = world.read_model((trail_id, proposer));
-            world.erase_model(@model);
+            world.write_model(@CollabReviewResult { trail_id, proposer, published_count, skipped_count });
         }
 
         // TODO: remove this?? is it necessary to call again?
@@ -468,16 +465,19 @@ pub mod designer {
                     Errors::NOT_YOUR_TRAIL,
                 );
                 if !owned.is_zero() && o.trail_id.is_non_zero() && !world.is_owner_of_trail(o.trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((o.trail_id, owned));
-                    assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 //
-                // Keep original creator address
+                // Resolve creator_address:
+                // - existing entity: always keep the original creator
+                // - new entity: use the address from the struct if non-zero (owner publishing on
+                //   behalf of a collaborator passes the proposer's address here), else use caller
                 let existing_entity: Option<Entity> = EntityImpl::get_entity(@world, o.inst);
                 o.creator_address = match existing_entity {
-                    // new entity: set caller as creator
-                    Option::None => {starknet::get_caller_address()},
-                    // entity exists: keep original creator
+                    Option::None => {
+                        if o.creator_address.is_non_zero() { o.creator_address }
+                        else { starknet::get_caller_address() }
+                    },
                     Option::Some(entity) => {entity.creator_address}
                 };
                 // write model
@@ -516,8 +516,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 world.write_model(@o);
             }
@@ -530,8 +529,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_pair(approval.w_description_texts.span(), o.inst, o.key.into()), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 world.write_model(@o);
             }
@@ -545,8 +543,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 world.write_model(@o);
             }
@@ -560,8 +557,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 world.write_model(@o);
             }
@@ -577,8 +573,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 world.write_model(@o);
             }
@@ -592,8 +587,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 world.write_model(@o);
             }
@@ -606,8 +600,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_pair(approval.w_multi_keys.span(), o.inst, o.key), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 let _result: Result<(), Error> = TriggerImpl::register_trigger(ref world, @o);
                 // if result.is_err() {
@@ -626,8 +619,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_pair(approval.w_multi_keys.span(), o.inst, o.key), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 world.write_model(@o);
             }
@@ -640,8 +632,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_pair(approval.w_multi_keys.span(), o.inst, o.key), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 world.write_model(@o);
             }
@@ -654,8 +645,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_pair(approval.w_multi_keys.span(), o.inst, o.key), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 let _result: Result<(), Error> = ActionImpl::register_action(ref world, @o);
                 // if result.is_err() {
@@ -674,8 +664,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 // Keep original trails -- NOT ALLOWED TO EDIT FROM EDITOR
                 // (trails are managed in the contract)
@@ -693,8 +682,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 TrailTrait::assert_trail_edit_protection(@world, @o);
                 o.append_to_hub(ref world);
@@ -709,8 +697,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 TrailTrait::assert_trail_parent_protection(@world, @o);
                 world.write_model(@o);
@@ -724,8 +711,7 @@ pub mod designer {
                 self._assert_can_edit_entity(@world, o.inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(o.inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.w_single_keys.span(), o.inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 TrailTrait::assert_trail_child_protection(@world, @o);
                 world.write_model(@o);
@@ -740,8 +726,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.d_single_keys.span(), inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 TrailTrait::assert_trail_delete_protection(@world, inst);
                 let model: Entity = world.read_model(inst);
@@ -769,8 +754,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.d_single_keys.span(), inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 TrailTrait::assert_trail_delete_protection(@world, inst);
                 let model: Reactable = world.read_model(inst);
@@ -785,8 +769,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_pair(approval.d_description_texts.span(), inst, key), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 TrailTrait::assert_trail_delete_protection(@world, inst);
                 let model: DescriptionText = world.read_model((inst, key),);
@@ -801,8 +784,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.d_single_keys.span(), inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 let model: Area = world.read_model(inst);
                 world.erase_model(@model);
@@ -816,8 +798,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.d_single_keys.span(), inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 TrailTrait::assert_trail_delete_protection(@world, inst);
                 let model: Exit = world.read_model(inst);
@@ -832,8 +813,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.d_single_keys.span(), inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 let model: InventoryItem = world.read_model(inst);
                 world.erase_model(@model);
@@ -847,8 +827,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.d_single_keys.span(), inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 let model: Container = world.read_model(inst);
                 world.erase_model(@model);
@@ -862,8 +841,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_pair(approval.d_multi_keys.span(), inst, key), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 let model: Trigger = world.read_model((inst, key),);
                 let _result: Result<(), Error> = TriggerImpl::unregister_trigger(ref world, @model);
@@ -884,8 +862,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_pair(approval.d_multi_keys.span(), inst, key), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 let model: Condition = world.read_model((inst, key),);
                 world.erase_model(@model);
@@ -899,8 +876,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_pair(approval.d_multi_keys.span(), inst, key), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 let model: Effect = world.read_model((inst, key),);
                 world.erase_model(@model);
@@ -914,8 +890,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_pair(approval.d_multi_keys.span(), inst, key), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 let model: Action = world.read_model((inst, key),);
                 let _result: Result<(), Error> = ActionImpl::unregister_action(ref world, @model);
@@ -936,8 +911,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.d_single_keys.span(), inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 let model: Hub = world.read_model(inst);
                 model.remove_trails_from_hub(ref world);
@@ -952,8 +926,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.d_single_keys.span(), inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 TrailTrait::assert_trail_delete_protection(@world, inst);
                 let model: Trail = world.read_model(inst);
@@ -969,8 +942,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.d_single_keys.span(), inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 let model: ParentToChildren = world.read_model(inst);
                 world.erase_model(@model);
@@ -984,8 +956,7 @@ pub mod designer {
                 self._assert_can_delete_entity(@world, inst, owned);
                 let trail_id: u128 = world.get_entity_trail_id(inst);
                 if !owned.is_zero() && trail_id.is_non_zero() && !world.is_owner_of_trail(trail_id, owned) {
-                    let approval: ApprovedProposal = world.read_model((trail_id, owned));
-                    assert(contains_inst(approval.d_single_keys.span(), inst), Errors::NOT_APPROVED);
+                    assert(false, Errors::NOT_APPROVED);
                 }
                 let model: ChildToParent = world.read_model(inst);
                 world.erase_model(@model);

--- a/packages/contracts/src/tests/collab_proposal_test.cairo
+++ b/packages/contracts/src/tests/collab_proposal_test.cairo
@@ -5,7 +5,7 @@ use lore::{
         entity::Entity,
         area::Area,
         description_text::DescriptionText,
-        collab_proposal::ApprovedProposal,
+        collab_proposal::CollabReviewResult,
     },
     systems::designer::IDesignerDispatcherTrait,
     tests::{
@@ -16,24 +16,11 @@ use lore::{
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
-const ENTITY_A: felt252 = 0x0A01;   // exists from start; collaborator modifies its area
-const ENTITY_B: felt252 = 0x0B01;   // exists from start; collaborator proposes deletion → owner rejects
-const ENTITY_C: felt252 = 0x0C01;   // new entity; collaborator creates → owner approves
+const ENTITY_A: felt252 = 0x0A01;   // exists from start; owner publishes modified area
+const ENTITY_B: felt252 = 0x0B01;   // exists from start; entity deletion skipped (owner decides)
+const ENTITY_C: felt252 = 0x0C01;   // new entity proposed by collaborator; owner publishes
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-fn make_empty_proposal(trail_id: u128, proposer: starknet::ContractAddress) -> ApprovedProposal {
-    ApprovedProposal {
-        trail_id,
-        proposer,
-        w_single_keys:       array![],
-        w_description_texts: array![],
-        w_multi_keys:        array![],
-        d_single_keys:       array![],
-        d_description_texts: array![],
-        d_multi_keys:        array![],
-    }
-}
+// ─── Setup helper ─────────────────────────────────────────────────────────────
 
 // OTHER() mints a trail, creates entity_A (area + description) and entity_B (area),
 // then grants RECIPIENT() collaborator access. Returns the trail_id.
@@ -76,186 +63,128 @@ fn owner_setup(ref sys: HelperSystems) -> u128 {
     trail_id
 }
 
-// ─── Full Collaborative Flow ──────────────────────────────────────────────────
-
-// Scenario:
-// 1. Owner (OTHER) publishes two entities with components and grants collaborator access.
-// 2. Collaborator (RECIPIENT) proposes: modify entity_A's area, create entity_C with
-//    area + description, delete entity_B.
-// 3. Owner approves area_A modification + entity_C creation but NOT entity_B deletion.
-// 4. Collaborator publishes all approved changes -they all succeed.
-// 5. entity_B remains intact because its deletion was not approved.
-#[test]
-fn test_collab_full_flow_approved_changes() {
-    let mut sys = setup_core();
-    let trail_id: u128 = owner_setup(ref sys);
-
-    // Collaborator prepares proposed changes
-    let modified_area_a = Area {
-        inst: ENTITY_A,
-        is_area: true,
-        is_spawn_point: false,
-        preserve_children: false,
-        progress_percentage: 75,
-    };
-    let new_entity_c = Entity {
-        inst: ENTITY_C,
-        is_entity: true,
-        trail_id,
-        name: "Hall C",
-        alt_names: array![],
-        actions_keys: array![],
-        creator_address: RECIPIENT(),
-    };
-    let new_area_c = Area {
-        inst: ENTITY_C,
-        is_area: true,
-        is_spawn_point: false,
-        preserve_children: false,
-        progress_percentage: 30,
-    };
-    let new_desc_c = DescriptionText { inst: ENTITY_C, key: 1, text: "A grand hall" };
-
-    // Step 2 -collaborator submits for review (emits event, no storage writes)
+// Shared submit helper — RECIPIENT() proposes: modify area_A, create entity_C + area_C + desc_C.
+fn collab_submit(ref sys: HelperSystems, trail_id: u128) {
     set_caller(RECIPIENT());
     sys.designer.submit_for_review(
         trail_id,
-        array![new_entity_c.clone()],                          // new entity
-        array![],                                              // reactables
-        array![modified_area_a.clone(), new_area_c.clone()],  // modified + new area
-        array![],                                              // exits
-        array![],                                              // hubs
-        array![new_desc_c.clone()],                           // new description_text
-        array![],                                              // inventory_items
-        array![],                                              // containers
-        array![],                                              // trails
-        array![],                                              // triggers
-        array![],                                              // conditions
-        array![],                                              // effects
-        array![],                                              // actions
-        array![],                                              // parents
-        array![],                                              // children
-        array![ENTITY_B],                                     // deleted entities
-        array![], array![], array![], array![], array![],     // deleted: reactable, area, exit, container, inventory_item
-        array![], array![], array![], array![],               // deleted: hub, trail, parent, child
-        array![], array![], array![], array![], array![],     // deleted keys: desc_text, trigger, condition, effect, action
+        array![Entity { inst: ENTITY_C, is_entity: true, trail_id, name: "Hall C", alt_names: array![], actions_keys: array![], creator_address: RECIPIENT() }],
+        array![],                                                // reactables
+        array![
+            Area { inst: ENTITY_A, is_area: true, is_spawn_point: false, preserve_children: false, progress_percentage: 75 },
+            Area { inst: ENTITY_C, is_area: true, is_spawn_point: false, preserve_children: false, progress_percentage: 30 },
+        ],
+        array![], array![],                                       // exits, hubs
+        array![DescriptionText { inst: ENTITY_C, key: 1, text: "A grand hall" }],
+        array![], array![], array![],                             // inventory_items, containers, trails
+        array![], array![], array![], array![],                   // triggers, conditions, effects, actions
+        array![], array![],                                       // parents, children
+        array![],                                                 // deleted_entity_insts (empty — collaborator cannot propose entity deletions)
+        array![], array![], array![], array![], array![],         // deleted: reactable, area, exit, container, inventory_item
+        array![], array![], array![], array![],                   // deleted: hub, trail, parent, child
+        array![], array![], array![], array![], array![],         // deleted keys: desc_text, trigger, condition, effect, action
     );
+}
 
-    // Step 3 -owner approves modification + creation; entity_B deletion intentionally omitted
+// ─── Full flow: owner publishes on behalf of collaborator ─────────────────────
+
+// Scenario:
+// 1. Owner creates entity_A + entity_B, grants RECIPIENT() access.
+// 2. Collaborator submits proposal: modify area_A, create entity_C + area_C + desc_C.
+// 3. Owner publishes all proposed changes directly (calling create_* from their own wallet).
+//    entity_C gets creator_address = RECIPIENT() because the owner passes it in the struct.
+// 4. Owner signals result: published_count=4, skipped_count=0.
+// 5. Verify all components on chain; CollabReviewResult model written.
+#[test]
+fn test_collab_owner_publishes_full_proposal() {
+    let mut sys = setup_core();
+    let trail_id: u128 = owner_setup(ref sys);
+    collab_submit(ref sys, trail_id);
+
+    // Owner publishes on behalf of collaborator
     set_caller(OTHER());
-    let mut approval = make_empty_proposal(trail_id, RECIPIENT());
-    // ENTITY_C (new entity) + ENTITY_A and ENTITY_C (area writes) all go in w_single_keys
-    approval.w_single_keys       = array![ENTITY_C, ENTITY_A, ENTITY_C];
-    // flat pairs [inst, key_as_felt252, ...] for DescriptionText
-    approval.w_description_texts = array![ENTITY_C, 1];
-    // d_single_keys left empty -entity_B deletion is rejected
-    sys.designer.approve_proposal(approval);
 
-    // Step 4 -collaborator publishes each approved change
+    // New entity — pass RECIPIENT() as creator_address so the collaborator is recorded as creator
+    sys.designer.create_entity(array![
+        Entity { inst: ENTITY_C, is_entity: true, trail_id, name: "Hall C", alt_names: array![], actions_keys: array![], creator_address: RECIPIENT() },
+    ]);
+    let stored_c: Entity = sys.world.read_model(ENTITY_C);
+    assert!(stored_c.is_entity, "entity_C should be created");
+    assert_eq!(stored_c.creator_address, RECIPIENT(), "entity_C creator should be RECIPIENT");
 
-    set_caller(RECIPIENT());
-
-    // Publish modified area_A -ENTITY_A is in w_single_keys → succeeds
-    sys.designer.create_area(array![modified_area_a]);
+    // Modified area_A
+    sys.designer.create_area(array![
+        Area { inst: ENTITY_A, is_area: true, is_spawn_point: false, preserve_children: false, progress_percentage: 75 },
+    ]);
     let stored_area_a: Area = sys.world.read_model(ENTITY_A);
-    assert_eq!(stored_area_a.progress_percentage, 75, "area_A should be updated to 75");
+    assert_eq!(stored_area_a.progress_percentage, 75, "area_A should be updated");
 
-    // Publish new entity_C -ENTITY_C is in w_single_keys → succeeds
-    sys.designer.create_entity(array![new_entity_c]);
-    let stored_entity_c: Entity = sys.world.read_model(ENTITY_C);
-    assert!(stored_entity_c.is_entity, "entity_C should be created");
-    assert_eq!(stored_entity_c.name, "Hall C", "entity_C name mismatch");
-    assert_eq!(stored_entity_c.trail_id, trail_id, "entity_C should belong to the trail");
+    // area_C
+    sys.designer.create_area(array![
+        Area { inst: ENTITY_C, is_area: true, is_spawn_point: false, preserve_children: false, progress_percentage: 30 },
+    ]);
 
-    // Publish new area_C (entity_C now exists in storage) -ENTITY_C in w_single_keys → succeeds
-    sys.designer.create_area(array![new_area_c]);
-    let stored_area_c: Area = sys.world.read_model(ENTITY_C);
-    assert!(stored_area_c.is_area, "area_C should be created");
-    assert_eq!(stored_area_c.progress_percentage, 30, "area_C progress mismatch");
-
-    // Publish description_text for entity_C -(ENTITY_C, 1) pair in w_description_texts → succeeds
-    sys.designer.create_description_text(array![new_desc_c]);
+    // desc_C
+    sys.designer.create_description_text(array![
+        DescriptionText { inst: ENTITY_C, key: 1, text: "A grand hall" },
+    ]);
     let stored_desc_c: DescriptionText = sys.world.read_model((ENTITY_C, 1_u32));
     assert_eq!(stored_desc_c.text, "A grand hall", "desc_C text mismatch");
 
-    // Step 5 -entity_B untouched; its deletion was not approved
-    let entity_b: Entity = sys.world.read_model(ENTITY_B);
-    assert!(entity_b.is_entity, "entity_B should still exist -deletion was rejected");
-    let area_b: Area = sys.world.read_model(ENTITY_B);
-    assert!(area_b.is_area, "area_B should still exist");
+    // Signal result — all 4 items published, 0 skipped
+    sys.designer.signal_review_result(trail_id, RECIPIENT(), 4, 0);
+    let result: CollabReviewResult = sys.world.read_model((trail_id, RECIPIENT()));
+    assert_eq!(result.published_count, 4, "published_count should be 4");
+    assert_eq!(result.skipped_count, 0, "skipped_count should be 0");
 }
 
-// Collaborator tries to delete entity_B even though the owner's ApprovedProposal
-// does not include it in d_single_keys -should panic.
+// Scenario: owner publishes only the area modification, skips entity_C creation.
+// Signal reflects partial publish; entity_B and entity_C untouched.
 #[test]
-#[should_panic(expected: ('DESIGNER: Not approved', 'ENTRYPOINT_FAILED'))]
-fn test_collab_delete_rejected_panics() {
+fn test_collab_owner_publishes_partial_proposal() {
     let mut sys = setup_core();
     let trail_id: u128 = owner_setup(ref sys);
+    collab_submit(ref sys, trail_id);
 
-    set_caller(RECIPIENT());
-    sys.designer.submit_for_review(
-        trail_id,
-        array![], array![], array![], array![], array![],
-        array![], array![], array![], array![], array![],
-        array![], array![], array![], array![], array![],
-        array![ENTITY_B],                                     // deleted entities
-        array![], array![], array![], array![], array![],     // deleted: reactable, area, exit, container, inventory_item
-        array![], array![], array![], array![],               // deleted: hub, trail, parent, child
-        array![], array![], array![], array![], array![],     // deleted keys: desc_text, trigger, condition, effect, action
-    );
-
-    // Owner approves only an area modification -entity_B deletion NOT included
     set_caller(OTHER());
-    let mut approval = make_empty_proposal(trail_id, RECIPIENT());
-    approval.w_single_keys = array![ENTITY_A];
-    sys.designer.approve_proposal(approval);
 
-    // Collaborator tries to delete entity_B → panic: NOT_APPROVED
-    set_caller(RECIPIENT());
-    sys.designer.delete_entity(array![ENTITY_B]);
+    // Owner only publishes the area_A modification
+    sys.designer.create_area(array![
+        Area { inst: ENTITY_A, is_area: true, is_spawn_point: false, preserve_children: false, progress_percentage: 75 },
+    ]);
+
+    // Signal partial result: 1 published, 3 skipped
+    sys.designer.signal_review_result(trail_id, RECIPIENT(), 1, 3);
+    let result: CollabReviewResult = sys.world.read_model((trail_id, RECIPIENT()));
+    assert_eq!(result.published_count, 1, "published_count should be 1");
+    assert_eq!(result.skipped_count, 3, "skipped_count should be 3");
+
+    // entity_C should not exist
+    let entity_c: Entity = sys.world.read_model(ENTITY_C);
+    assert!(!entity_c.is_entity, "entity_C should not have been created");
 }
 
-// ─── Access Control Edge Cases ────────────────────────────────────────────────
-
-// A user with no trail role at all cannot submit for review.
+// Scenario: owner rejects entirely — signals published_count=0, skipped_count=total.
 #[test]
-#[should_panic(expected: ('DESIGNER: Not collaborator', 'ENTRYPOINT_FAILED'))]
-fn test_submit_for_review_by_stranger_panics() {
-    let mut sys = setup_core();
-    // Mint trail for OTHER() but do NOT grant RECIPIENT() any access
-    let (_entity_trail, trail, _exit) = _mint_trail(ref sys, OTHER());
-    let trail_id: u128 = trail.trail_id;
-
-    set_caller(RECIPIENT());
-    sys.designer.submit_for_review(
-        trail_id,
-        array![], array![], array![], array![], array![],
-        array![], array![], array![], array![], array![],
-        array![], array![], array![], array![], array![],
-        array![],                                             // deleted entities
-        array![], array![], array![], array![], array![],     // deleted: reactable, area, exit, container, inventory_item
-        array![], array![], array![], array![],               // deleted: hub, trail, parent, child
-        array![], array![], array![], array![], array![],     // deleted keys: desc_text, trigger, condition, effect, action
-    );
-}
-
-// A collaborator cannot call approve_proposal -only the trail owner or admin can.
-#[test]
-#[should_panic(expected: ('DESIGNER: Not trail owner', 'ENTRYPOINT_FAILED'))]
-fn test_approve_by_collaborator_panics() {
+fn test_collab_owner_signals_rejection() {
     let mut sys = setup_core();
     let trail_id: u128 = owner_setup(ref sys);
+    collab_submit(ref sys, trail_id);
 
-    let proposal = make_empty_proposal(trail_id, RECIPIENT());
-    set_caller(RECIPIENT());
-    sys.designer.approve_proposal(proposal);
+    set_caller(OTHER());
+    sys.designer.signal_review_result(trail_id, RECIPIENT(), 0, 4);
+    let result: CollabReviewResult = sys.world.read_model((trail_id, RECIPIENT()));
+    assert_eq!(result.published_count, 0, "published_count should be 0 for rejection");
+    assert_eq!(result.skipped_count, 4, "skipped_count should be 4 for full rejection");
 }
 
-// Without any approve_proposal call, a collaborator cannot write components.
+// ─── Access control: collaborators cannot write directly to trail entities ────
+
+// A collaborator who has been granted trail access cannot call create_area directly.
+// They must go through submit_for_review; the owner publishes.
 #[test]
 #[should_panic(expected: ('DESIGNER: Not approved', 'ENTRYPOINT_FAILED'))]
-fn test_collab_write_without_approval_panics() {
+fn test_collab_cannot_write_directly() {
     let mut sys = setup_core();
     let _trail_id: u128 = owner_setup(ref sys);
 
@@ -269,9 +198,86 @@ fn test_collab_write_without_approval_panics() {
     }]);
 }
 
-// The trail owner never needs an ApprovedProposal -can write freely.
+// A collaborator cannot delete a component directly on a trail entity.
 #[test]
-fn test_trail_owner_bypasses_approval_gate() {
+#[should_panic(expected: ('DESIGNER: Not approved', 'ENTRYPOINT_FAILED'))]
+fn test_collab_cannot_delete_component_directly() {
+    let mut sys = setup_core();
+    let _trail_id: u128 = owner_setup(ref sys);
+
+    set_caller(RECIPIENT());
+    sys.designer.delete_area(array![ENTITY_A]);
+}
+
+// A collaborator cannot delete an entity directly.
+#[test]
+#[should_panic(expected: ('DESIGNER: Not approved', 'ENTRYPOINT_FAILED'))]
+fn test_collab_cannot_delete_entity_directly() {
+    let mut sys = setup_core();
+    let _trail_id: u128 = owner_setup(ref sys);
+
+    set_caller(RECIPIENT());
+    sys.designer.delete_entity(array![ENTITY_B]);
+}
+
+// A collaborator cannot include entity deletions in their proposal.
+#[test]
+#[should_panic(expected: ('DESIGNER: Not trail owner', 'ENTRYPOINT_FAILED'))]
+fn test_collab_cannot_propose_entity_deletion() {
+    let mut sys = setup_core();
+    let trail_id: u128 = owner_setup(ref sys);
+
+    set_caller(RECIPIENT());
+    sys.designer.submit_for_review(
+        trail_id,
+        array![], array![], array![], array![], array![],
+        array![], array![], array![], array![], array![],
+        array![], array![], array![], array![], array![],
+        array![ENTITY_B],                                         // collaborator tries to propose entity deletion
+        array![], array![], array![], array![], array![],
+        array![], array![], array![], array![],
+        array![], array![], array![], array![], array![],
+    );
+}
+
+// A stranger (no trail role) cannot call submit_for_review.
+#[test]
+#[should_panic(expected: ('DESIGNER: Not collaborator', 'ENTRYPOINT_FAILED'))]
+fn test_submit_for_review_by_stranger_panics() {
+    let mut sys = setup_core();
+    let (_entity_trail, trail, _exit) = _mint_trail(ref sys, OTHER());
+    let trail_id: u128 = trail.trail_id;
+
+    set_caller(RECIPIENT());
+    sys.designer.submit_for_review(
+        trail_id,
+        array![], array![], array![], array![], array![],
+        array![], array![], array![], array![], array![],
+        array![], array![], array![], array![], array![],
+        array![],
+        array![], array![], array![], array![], array![],
+        array![], array![], array![], array![],
+        array![], array![], array![], array![], array![],
+    );
+}
+
+// Only the trail owner or admin can call signal_review_result.
+#[test]
+#[should_panic(expected: ('DESIGNER: Not trail owner', 'ENTRYPOINT_FAILED'))]
+fn test_signal_review_result_by_non_owner_panics() {
+    let mut sys = setup_core();
+    let trail_id: u128 = owner_setup(ref sys);
+    collab_submit(ref sys, trail_id);
+
+    set_caller(RECIPIENT());
+    sys.designer.signal_review_result(trail_id, RECIPIENT(), 4, 0);
+}
+
+// ─── Owner and admin bypass the gate ─────────────────────────────────────────
+
+// The trail owner never needs to go through review — can write freely.
+#[test]
+fn test_trail_owner_bypasses_gate() {
     let mut sys = setup_core();
     let _trail_id: u128 = owner_setup(ref sys);
 
@@ -287,9 +293,9 @@ fn test_trail_owner_bypasses_approval_gate() {
     assert_eq!(stored.progress_percentage, 55, "trail owner can update freely");
 }
 
-// Admin (OWNER) also bypasses all gates.
+// Admin also bypasses all gates.
 #[test]
-fn test_admin_bypasses_approval_gate() {
+fn test_admin_bypasses_gate() {
     let mut sys = setup_core();
     let _trail_id: u128 = owner_setup(ref sys);
 

--- a/packages/contracts/src/tests/helpers.cairo
+++ b/packages/contracts/src/tests/helpers.cairo
@@ -102,7 +102,7 @@ fn namespace_def() -> NamespaceDef {
             TestResource::Model(models::player_account::m_PlayerBalances::TEST_CLASS_HASH.into()),
             TestResource::Model(models::actions_config::m_ActionsConfig::TEST_CLASS_HASH.into()),
             TestResource::Model(models::actions_config::m_ActionsReward::TEST_CLASS_HASH.into()),
-            TestResource::Model(models::collab_proposal::m_ApprovedProposal::TEST_CLASS_HASH.into()),
+            TestResource::Model(models::collab_proposal::m_CollabReviewResult::TEST_CLASS_HASH.into()),
             TestResource::Event(models::collab_proposal::e_CollabProposalEvent::TEST_CLASS_HASH.into()),
             TestResource::Event(lore::lib::access::e_AccessGrantedEvent::TEST_CLASS_HASH.into()),
             // game_token


### PR DESCRIPTION
# Description

Adjusted collaborative working pipeline. Owner of trail publishes submitted changes from collaborators instead of them.

## Related issues

Closes #<issue_number>


## Introduced changes
- Removed ApprovedProposal model as collaborators no longer publish changes, only submit for review.
- Added ReviewResult model that will notify collaborator of his submission result: all published, all rejected, some published some rejected. One model per collaborator.
- Updated collaborative documentation.

## Checklist
- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
